### PR TITLE
Add workflow for deploying GitHub pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install package
         run: |
-          pip install -e '.[docs]' --no-deps
+          pip install -e '.[doc]'
         shell: micromamba-shell {0}
 
       - name: Check environment consistency


### PR DESCRIPTION
With this we can deploy GitHub pages directly from the actions pipeline, no need to have a separate branch with the source of the pages.