### PR TITLE
Remove PySCF<2.10 constraint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        pyscf-version: ["2.9", "2.11"]
 
+    name: "Python=${{ matrix.python-version }} & PySCF=${{ matrix.pyscf-version }}"
     steps:
     - uses: actions/checkout@v4
 
@@ -29,6 +31,7 @@ jobs:
         cache-downloads: true
         create-args: >-
           python=${{ matrix.python-version }}
+          pyscf=${{ matrix.pyscf-version }}
 
     - name: Install package in development mode
       run: |

--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -9,7 +9,7 @@ dependencies:
   - e3nn
   - numpy
   - opt_einsum_fx
-  - pyscf<2.10.0
+  - pyscf
   - python
   - pytorch * cpu_*
   - qcelemental

--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -9,7 +9,7 @@ dependencies:
   - e3nn
   - numpy
   - opt_einsum_fx
-  - pyscf<2.10.0
+  - pyscf
   - python
   - pytorch-gpu
   - qcelemental

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "huggingface_hub",
     "numpy",
     "opt_einsum_fx",
-    "pyscf<2.10.0",
+    "pyscf",
     "qcelemental",
     "torch"
 ]

--- a/src/skala/ase/calculator.py
+++ b/src/skala/ase/calculator.py
@@ -44,6 +44,7 @@ class Skala(Calculator):  # type: ignore[misc]
         "with_dftd3": True,
         "charge": None,
         "multiplicity": None,
+        "auxbasis": None,
         "verbose": 0,
     }
 
@@ -85,6 +86,7 @@ class Skala(Calculator):  # type: ignore[misc]
             or "with_density_fit" in changed_parameters
             or "with_newton" in changed_parameters
             or "with_dftd3" in changed_parameters
+            or "auxbasis" in changed_parameters
         ):
             self._ks = None
             self.reset()
@@ -162,6 +164,7 @@ class Skala(Calculator):  # type: ignore[misc]
                 with_density_fit=bool(self.parameters.with_density_fit),
                 with_newton=bool(self.parameters.with_newton),
                 with_dftd3=bool(self.parameters.with_dftd3),
+                auxbasis=self.parameters.auxbasis,
             ).nuc_grad_method()
             self._ks = grad_method
         else:

--- a/src/skala/pyscf/__init__.py
+++ b/src/skala/pyscf/__init__.py
@@ -69,7 +69,7 @@ def SkalaKS(
     >>>
     >>> mol = gto.M(atom="H 0 0 0; H 0 0 1", basis="def2-svp")
     >>> ks = SkalaKS(mol, xc=load_functional("skala"))
-    >>> ks = ks.density_fit()  # Optional: use density fitting
+    >>> ks = ks.density_fit(auxbasis="def2-svp-jkfit")  # Optional: use density fitting
     >>> ks = ks.set(verbose=0)
     >>> energy = ks.kernel()
     >>> print(energy)  # DOCTEST: Ellipsis
@@ -149,7 +149,7 @@ def SkalaRKS(
     >>> from skala.pyscf import SkalaRKS
     >>>
     >>> mol = gto.M(atom="H 0 0 0; H 0 0 1", basis="def2-svp")
-    >>> ks = SkalaRKS(mol, xc="skala", with_density_fit=True)(verbose=0)
+    >>> ks = SkalaRKS(mol, xc="skala", with_density_fit=True, auxbasis="def2-svp-jkfit")(verbose=0)
     >>> ks  # DOCTEST: Ellipsis
     <pyscf.df.df_jk.DFSkalaRKS object at ...>
     >>> energy = ks.kernel()
@@ -223,7 +223,7 @@ def SkalaUKS(
     >>> from skala.pyscf import SkalaUKS
     >>>
     >>> mol = gto.M(atom="H", basis="def2-svp", spin=1)
-    >>> ks = SkalaUKS(mol, xc="skala", with_density_fit=True)(verbose=0)
+    >>> ks = SkalaUKS(mol, xc="skala", with_density_fit=True, auxbasis="def2-svp-jkfit")(verbose=0)
     >>> ks  # DOCTEST: Ellipsis
     <pyscf.df.df_jk.DFSkalaUKS object at ...>
     >>> energy = ks.kernel()

--- a/src/skala/pyscf/dft.py
+++ b/src/skala/pyscf/dft.py
@@ -54,7 +54,6 @@ from collections.abc import Callable
 from typing import Any, cast
 
 import numpy as np
-import torch
 from dftd3.pyscf import DFTD3Dispersion
 from pyscf import dft, gto
 from pyscf.df import df_jk
@@ -75,7 +74,7 @@ class SkalaRKS(dft.rks.RKS):  # type: ignore[misc]
     def __init__(self, mol: gto.Mole, xc: ExcFunctionalBase):
         super().__init__(mol, xc="custom")
         self._keys.add("with_dftd3")
-        self._numint = SkalaNumInt(xc, device=torch.device("cpu"))
+        self._numint = SkalaNumInt(xc)
 
         d3 = xc.get_d3_settings()
         self.with_dftd3 = DFTD3Dispersion(mol, d3) if d3 is not None else None
@@ -127,7 +126,7 @@ class SkalaUKS(dft.uks.UKS):  # type: ignore[misc]
     def __init__(self, mol: gto.Mole, xc: ExcFunctionalBase):
         super().__init__(mol, xc="custom")
         self._keys.add("with_dftd3")
-        self._numint = SkalaNumInt(xc, device=torch.device("cpu"))
+        self._numint = SkalaNumInt(xc)
 
         d3 = xc.get_d3_settings()
         self.with_dftd3 = DFTD3Dispersion(mol, d3) if d3 is not None else None

--- a/tests/test_ase.py
+++ b/tests/test_ase.py
@@ -19,7 +19,9 @@ def xc(request) -> str:
 @pytest.mark.skipif(ase is None, reason="ASE is not installed")
 def test_calc(xc: str) -> None:
     atoms = molecule("H2O")
-    atoms.calc = Skala(xc=xc, basis="def2-svp", with_density_fit=True)
+    atoms.calc = Skala(
+        xc=xc, basis="def2-svp", with_density_fit=True, auxbasis="def2-svp-jkfit"
+    )
 
     energy = atoms.get_potential_energy()
 


### PR DESCRIPTION
Before PySCF 2.10

- density fitting would always use jkfit auxbasis independent of whether xc functional is hybrid or not

PySCF 2.10 or later

- auxbasis now detected based on whether xc functional is hybrid or not, jfit used for non-hybrids and jkfit used for hybrids

Updates:

- [x] specify auxbasis explicitly in tests where the auxbasis change will give a significant change in result
- [x] remove constraint on PySCF version (maybe add PySCF<2.12 just to be safe?)
- [x] test PySCF<2.10 and PySCF>=2.10 in CI
- [ ] add a warning if skala is used with auxbasis=None?

Closes #16 