### PR TITLE
Add documentation for using GPU4PySCF

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ Please stay tuned for updates and new releases.
 
    installation
    pyscf/singlepoint
+   pyscf/gpu4pyscf
    pyscf/scf_settings
    ase
    ftorch

--- a/docs/pyscf/gpu4pyscf.rst
+++ b/docs/pyscf/gpu4pyscf.rst
@@ -1,0 +1,44 @@
+Using Skala with gpu4pyscf
+==========================
+
+The Skala functional can also be used in GPU4PySCF with an appropriate PyTorch CUDA version by creating a new Kohn-Sham calculator based on the `SkalaKS` constructor from the ``skala.gpu4pyscf`` module.
+
+.. code-block:: python
+
+   from pyscf import gto
+
+   from skala.gpu4pyscf import SkalaKS
+
+   mol = gto.M(
+       atom="""H 0 0 0; H 0 0 1.4""",
+       basis="def2-tzvp",
+   )
+   ks = SkalaKS(mol, xc="skala")
+   ks.kernel()
+
+   print(ks.dump_scf_summary())
+
+
+Installation
+------------
+
+Install the latest version of the ``skala`` package from PyPI or conda-forge together with a compatible PyTorch CUDA version.
+For pip the default PyTorch installation will be used, which is typically the latest version with CUDA support.
+
+.. code-block:: bash
+
+   pip install skala cupy-cuda12x cutensor-cuda12x
+
+For conda-forge, select the pytorch CUDA version that matches your system and CUDA installation. For example, for CUDA 12.8:
+
+.. code-block:: bash
+
+   mamba install -c conda-forge skala 'cuda-version=12.*' 'pytorch=*=cuda*' cupy cutensor
+
+In both cases you need to install GPU4PySCF separately from PyPI.
+
+.. code-block:: bash
+
+   pip install --no-deps "gpu4pyscf-cuda12x>=1.0,<2" "gpu4pyscf-libxc-cuda12x>=0.4,<1"
+
+We are using ``--no-deps`` to avoid overriding the already installed cupy and cutensor packages in the previous step.

--- a/docs/pyscf/singlepoint.ipynb
+++ b/docs/pyscf/singlepoint.ipynb
@@ -104,37 +104,6 @@
     "\n",
     "print(ks.dump_scf_summary())"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fd56964d",
-   "metadata": {},
-   "source": [
-    "# Using the Skala functional in GPU4PySCF\n",
-    "\n",
-    "The Skala functional can also be used in GPU4PySCF with an appropriate PyTorch CUDA version by creating a new Kohn-Sham calculator based on the `SkalaKS` constructor from the `skala.gpu4pyscf`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cec1b5f9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from pyscf import gto\n",
-    "\n",
-    "from skala.gpu4pyscf import SkalaKS\n",
-    "\n",
-    "mol = gto.M(\n",
-    "    atom=\"\"\"H 0 0 0; H 0 0 1.4\"\"\",\n",
-    "    basis=\"def2-tzvp\",\n",
-    ")\n",
-    "ks = SkalaKS(mol, xc=\"skala\")\n",
-    "ks.kernel()\n",
-    "\n",
-    "print(ks.dump_scf_summary())"
-   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Since we don't have a GPU runner in our CI we can't run the notebook cell for GPU4PySCF, which leads to broken output. Instead of having it as part of the notebook, this PR moves the GPU4PySCF instructions to a separate rst page.