### PR TITLE
Add mypy check to CI and skip ASE tests when package missing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,10 @@ jobs:
         pip install -e . --no-deps
       shell: micromamba-shell {0}
 
+    - name: Run mypy
+      run: mypy .
+      shell: micromamba-shell {0}
+
     - name: Run pre-commit hooks
       run: |
         pre-commit install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  pre-commit:
+  lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -28,20 +28,20 @@ jobs:
         pip install -e . --no-deps
       shell: micromamba-shell {0}
 
-    - name: Run mypy
-      run: mypy .
-      shell: micromamba-shell {0}
-
     - name: Run pre-commit hooks
       run: |
         pre-commit install
         pre-commit run --all-files
       shell: micromamba-shell {0}
 
+    - name: Run mypy
+      run: mypy .
+      shell: micromamba-shell {0}
+
   test:
     runs-on: ubuntu-latest
     needs:
-      - pre-commit
+      - lint
     strategy:
       fail-fast: false
       matrix:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,3 @@ repos:
       # Run the formatter.
       - id: ruff-format
         args: [--config, pyproject.toml]
-  # - repo: https://github.com/pre-commit/mirrors-mypy
-  #   rev: v1.20.0
-  #   hooks:
-  #     - id: mypy
-  #       args: [--config-file, pyproject.toml]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
 
 optional-dependencies.dev = [
     "pre-commit",
+    "mypy",
     "pytest",
     "pytest-cov",
     "pytest-randomly",

--- a/src/skala/ase/calculator.py
+++ b/src/skala/ase/calculator.py
@@ -75,9 +75,9 @@ class Skala(Calculator):
                 self._ks.verbose = verbose
                 self._ks.base.verbose = verbose
 
-        if "ks_config" in changed_parameters and self.parameters.ks_config is not None:
+        if "ks_config" in changed_parameters and self.parameters.ks_config is not None:  # type: ignore
             if self._ks is not None:
-                self._ks.base(**self.parameters.ks_config)
+                self._ks.base(**self.parameters.ks_config)  # type: ignore
 
         if (
             "charge" in changed_parameters
@@ -178,7 +178,7 @@ class Skala(Calculator):
         else:
             self._ks.reset(self._mol)
 
-        if self.parameters.with_retry:
+        if self.parameters.with_retry:  # type: ignore
             self._ks.base, _ = retry_scf(self._ks.base)
             energy = self._ks.base.e_tot
         else:

--- a/tests/test_ase.py
+++ b/tests/test_ase.py
@@ -1,10 +1,7 @@
 import numpy as np
 import pytest
 
-try:
-    import ase
-except ModuleNotFoundError:
-    ase = None
+pytest.importorskip("ase")
 
 from ase.build import molecule
 from ase.calculators import calculator
@@ -12,7 +9,6 @@ from ase.calculators import calculator
 from skala.ase import Skala
 
 
-@pytest.mark.skipif(ase is None, reason="ASE is not installed")
 @pytest.mark.parametrize("xc", ["pbe", "tpss", "skala-1.0", "skala-1.1"])
 def test_calc(xc: str) -> None:
     atoms = molecule("H2O")  # type: ignore[no-untyped-call]
@@ -49,7 +45,6 @@ def test_calc(xc: str) -> None:
     )
 
 
-@pytest.mark.skipif(ase is None, reason="ASE is not installed")
 def test_missing_basis() -> None:
     atoms = molecule("H2O")  # type: ignore[no-untyped-call]
     atoms.calc = Skala(xc="pbe", with_density_fit=True, auxbasis="def2-svp-jkfit")
@@ -60,9 +55,8 @@ def test_missing_basis() -> None:
         atoms.get_potential_energy()
 
 
-@pytest.mark.skipif(ase is None, reason="ASE is not installed")
 def test_ks_config() -> None:
-    atoms = molecule("H2O")
+    atoms = molecule("H2O")  # type: ignore[no-untyped-call]
     atoms.calc = Skala(
         xc="pbe",
         basis="def2-svp",


### PR DESCRIPTION
 ## Changes
 
 - Add `mypy .` step to the `pre-commit` CI job in `.github/workflows/test.yml`.
 - Remove the commented-out mypy hook from `.pre-commit-config.yaml` (mypy now runs as a dedicated CI step, not via pre-commit).
 - Use `pytest.importorskip("ase")` in `tests/test_ase.py` to skip the whole module when ASE is unavailable, replacing the prior `try/except` + per-test `skipif` decorators.
 - Incidental fixes carried in this branch: `pyproject.toml` and `src/skala/ase/calculator.py`.