### PR TITLE
Fix grid alignment padding mismatch with gpu4pyscf

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skala"
-version = "2026.2"
+version = "2026.3"
 description = "Skala Exchange Correlation Functional"
 authors = []
 license-files = ["LICENSE.txt"]

--- a/src/skala/pyscf/dft.py
+++ b/src/skala/pyscf/dft.py
@@ -50,6 +50,7 @@ The provided classes support the same transformations and methods as the origina
 <pyscf.scf.hf.DFSkalaRKS_Scanner object at ...>
 """
 
+import logging
 import warnings
 from collections.abc import Callable
 from typing import Any, cast
@@ -66,6 +67,8 @@ from skala.pyscf.gradients import SkalaRKSGradient, SkalaUKSGradient
 from skala.pyscf.numint import SkalaNumInt
 from skala.pyscf.utils import pyscf_version_newer_than_2_10
 
+logger = logging.getLogger(__name__)
+
 
 def _needs_unsorted_grids(func: ExcFunctionalBase) -> bool:
     """Return True when the functional needs per-atom grid ordering."""
@@ -75,7 +78,19 @@ def _needs_unsorted_grids(func: ExcFunctionalBase) -> bool:
 def _build_grids_unsorted(
     grids: dft.gen_grid.Grids, mol: gto.Mole
 ) -> dft.gen_grid.Grids:
-    """Build grids without sorting, preserving per-atom ordering."""
+    """Build grids without sorting, preserving per-atom ordering.
+
+    Also disables grid alignment padding, which would introduce extra
+    zero-weight grid points that are not accounted for in the per-atom
+    grid size decomposition used by the Skala functional.
+    """
+    if grids.alignment != 1:
+        logger.debug(
+            "Overriding grids.alignment from %d to 1. "
+            "The Skala functional requires unsorted, unpadded grids.",
+            grids.alignment,
+        )
+        grids.alignment = 1
     grids.build(mol, sort_grids=False)
     return grids
 

--- a/src/skala/pyscf/features.py
+++ b/src/skala/pyscf/features.py
@@ -111,6 +111,16 @@ def generate_features(
         )
         sizes = [len(atom_grids_tab[mol.atom_symbol(ia)][1]) for ia in range(mol.natm)]
 
+        n_atomic = sum(sizes)
+        n_grid = grids.weights.shape[0]
+        if n_atomic != n_grid:
+            raise ValueError(
+                f"Grid size mismatch: sum of atomic grid sizes ({n_atomic}) does not match "
+                f"total grid points ({n_grid}). This is likely caused by grid alignment padding "
+                f"(grids.alignment={getattr(grids, 'alignment', '?')}). "
+                f"Set grids.alignment = 1 before building grids to disable padding."
+            )
+
         if "atomic_grid_sizes" in features:
             mol_features["atomic_grid_sizes"] = torch.tensor(
                 sizes, dtype=torch.long, device=dm.device

--- a/tests/test_pyscf_classes.py
+++ b/tests/test_pyscf_classes.py
@@ -79,3 +79,33 @@ def test_skala_class(
     ks = grad.base
     assert isinstance(ks, SkalaRKS if mol.spin == 0 else SkalaUKS)
     assert ks.with_dftd3 is not None if with_dftd3 else ks.with_dftd3 is None
+
+
+def test_grid_alignment_mismatch_raises() -> None:
+    """generate_features raises ValueError when grid has alignment padding."""
+    from unittest.mock import patch
+
+    import torch
+
+    from skala.pyscf.features import generate_features
+
+    mol = gto.M(atom="H 0 0 0; H 0 0 0.74", basis="sto-3g", verbose=0)
+    func = load_functional("skala-1.1")
+
+    def _build_grids_keep_padding(grids: gto.Mole, mol: gto.Mole) -> gto.Mole:
+        """Build grids WITHOUT disabling alignment, so padding is preserved."""
+        grids.build(mol, sort_grids=False)
+        return grids
+
+    with patch("skala.pyscf.dft._build_grids_unsorted", _build_grids_keep_padding):
+        ks = SkalaKS(mol, xc=func, with_dftd3=False)
+
+    # The default PySCF alignment is 8, so grids may have padding.
+    # Force alignment to something large to guarantee a mismatch.
+    ks.grids.alignment = 128
+    ks.grids.build(mol, sort_grids=False)
+
+    dm = torch.from_numpy(ks.get_init_guess())
+
+    with pytest.raises(ValueError, match="Grid size mismatch"):
+        generate_features(mol, dm, ks.grids, set(func.features))

--- a/tests/test_pyscf_classes.py
+++ b/tests/test_pyscf_classes.py
@@ -91,6 +91,7 @@ def test_grid_alignment_mismatch_raises() -> None:
 
     mol = gto.M(atom="H 0 0 0; H 0 0 0.74", basis="sto-3g", verbose=0)
     func = load_functional("skala-1.1")
+    assert not isinstance(func, str)
 
     def _build_grids_keep_padding(grids: gto.Mole, mol: gto.Mole) -> gto.Mole:
         """Build grids WITHOUT disabling alignment, so padding is preserved."""


### PR DESCRIPTION
Set grids.alignment=1 in _build_grids_unsorted to prevent PySCF/gpu4pyscf from appending zero-weight padding points that cause size mismatches in Skala's feature generation pipeline.

- Force alignment=1 in _build_grids_unsorted with debug log when overriding
- Add ValueError check in generate_features when grid sizes don't match
- Add negative test confirming ValueError fires without the fix