### PR TITLE
Make installation of Skala with GPU support easier

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -13,6 +13,14 @@ jobs:
       fail-fast: false
       matrix:
         package: [skala, microsoft-skala]
+        cuda: ['']
+        include:
+          - package: skala-cuda
+            cuda: 11x
+          - package: skala-cuda
+            cuda: 12x
+          - package: skala-cuda
+            cuda: 13x
 
     steps:
     - uses: actions/checkout@v4
@@ -42,13 +50,25 @@ jobs:
         sed -e "s/@VERSION@/$VERSION/g" .github/workflows/pypi/microsoft-skala.toml > pyproject.toml
         cat pyproject.toml
 
+    - name: Replace pyproject.toml
+      if: ${{ matrix.package == 'skala-cuda' }}
+      run: |
+        VERSION=$(python3 -c "from tomllib import load; print(load(open('pyproject.toml', 'rb'))['project']['version'])")
+        CUDA=${{ matrix.cuda }}
+        rm -r src/skala
+        mkdir -p src/skala_cuda
+        echo "from skala import *" > src/skala_cuda/__init__.py
+        touch src/skala_cuda/py.typed
+        sed -e "s/@VERSION@/$VERSION/g" -e "s/@CUDA@/$CUDA/g" .github/workflows/pypi/skala-cuda.toml > pyproject.toml
+        cat pyproject.toml
+
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
 
     - name: Store the distribution packages
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ matrix.package }}-pkg
+        name: ${{ matrix.package }}${{ matrix.cuda }}-pkg
         path: dist/
 
   publish-to-pypi:
@@ -60,7 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [skala, microsoft-skala]
+        package: [skala, microsoft-skala, skala-cuda11x, skala-cuda12x, skala-cuda13x]
     environment:
       name: pypi
       url: https://pypi.org/p/${{ matrix.package }}

--- a/.github/workflows/pypi/skala-cuda.toml
+++ b/.github/workflows/pypi/skala-cuda.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "skala-cuda@CUDA@"
+version = "@VERSION@"
+description = "Skala Exchange Correlation Functional"
+authors = []
+license-files = ["LICENSE.txt"]
+readme = "README.md"
+keywords = []
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Development Status :: 5 - Production/Stable",
+]
+requires-python = ">=3.10"
+dependencies = [
+    "skala==@VERSION@",
+    "gpu4pyscf-cuda@CUDA@>=1.5,<1.8",
+]
+urls.repository = "https://github.com/microsoft/skala"
+urls.documentation = "https://microsoft.github.io/skala"
+urls.homepage = "https://aka.ms/dft"

--- a/README.md
+++ b/README.md
@@ -77,9 +77,19 @@ ks.kernel()
 ## Getting started: GPU4PySCF (GPU)
 
 The GPU install is more involved because `gpu4pyscf` ships CUDA-version-specific
-wheels that must match your CUDA toolkit. The recommended path is the provided
-[`environment-gpu.yml`](environment-gpu.yml), which pins `pytorch-gpu`,
-`cuda-toolkit` 12, `cutensor`, and installs `gpu4pyscf-cuda12x` 1.5 from PyPI:
+wheels that must match your CUDA toolkit.
+
+To install all dependencies from PyPI, use the GPU specific package with the
+matching CUDA version, e.g., for CUDA 12:
+
+```bash
+pip install skala-cuda12x
+```
+
+The `skala-cuda11x` and `skala-cuda13x` packages are also available for CUDA 11 and 13, respectively.
+
+The recommended path is the provided [`environment-gpu.yml`](environment-gpu.yml),
+which pins `pytorch-gpu`, `cuda-toolkit` 12, `cutensor`, and installs `gpu4pyscf-cuda12x` from PyPI:
 
 ```bash
 mamba env create -n skala -f environment-gpu.yml


### PR DESCRIPTION
Add pypi packages which automatically install the correct version of gpu4pyscf together with the main skala package.