### PR TITLE
Fix 2 retry pipeline bugs on GPU

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skala"
-version = "2026.4"
+version = "2026.5"
 description = "Skala Exchange Correlation Functional"
 authors = []
 license-files = ["LICENSE.txt"]

--- a/src/skala/pyscf/retry.py
+++ b/src/skala/pyscf/retry.py
@@ -86,10 +86,10 @@ class SCFState:
         if "norm_ddm" not in envs:
             envs["norm_ddm"] = np.linalg.norm(envs["dm"] - envs["dm_last"])
 
-        norm_ddm = envs["norm_ddm"]
-        assert isinstance(norm_ddm, (float, int)), (
-            f"Expected norm_ddm to be a float, got {type(norm_ddm)}"
-        )
+        # gpu4pyscf stores norm_ddm as a 0-d cupy.ndarray; CPU pyscf as a numpy
+        # scalar. Coerce to a Python float so downstream consumers (and the
+        # `dm_change_per_cycle` list) always see a uniform numeric type.
+        norm_ddm = float(envs["norm_ddm"])
         self.dm_change_per_cycle.append(norm_ddm)
 
         if not isinstance(mo_energy, list) and len(mo_energy.shape) == 1:
@@ -194,13 +194,13 @@ def retry_scf(
 
 
 def increment_level_shift(
-    level_shift: float,
+    level_shift: float | None,
     max_level_shift: float = 0.5,
     level_shift_init: float = 0.1,
     level_shift_increment: float = 0.2,
 ) -> float:
-    return (
-        min(level_shift + level_shift_increment, max_level_shift)
-        if level_shift > 0
-        else level_shift_init
-    )
+    # gpu4pyscf SCF objects default ``level_shift`` to None, CPU pyscf uses 0.
+    # Treat both as "no level shift yet" and start from ``level_shift_init``.
+    if not level_shift:
+        return level_shift_init
+    return min(level_shift + level_shift_increment, max_level_shift)


### PR DESCRIPTION
The retry path in src/skala/pyscf/retry.py contained two gpu4pyscf incompatibilities that together caused single-point calculations to fail on GPU but succeed on CPU for systems whose first SCF call did not converge.

1. SCFState.post_cycle_callback asserted isinstance(envs["norm_ddm"], (float, int)) but gpu4pyscf stores norm_ddm as a 0-d cupy.ndarray, so the assertion fires on the first GPU SCF cycle. This PR always converts to float to make gpu4pyscf and pyscf compatible.

2. increment_level_shift did `if level_shift > 0`. CPU pyscf defaults SCF.level_shift to 0, gpu4pyscf defaults it to None, so the comparison raises TypeError on the GPU retry path. This PR treats None and 0 identically as "no level shift yet" and start from level_shift_init.