### PR TITLE
test: load each functional once per session to avoid HF Hub 429

### DIFF
--- a/src/skala/pyscf/numint.py
+++ b/src/skala/pyscf/numint.py
@@ -245,7 +245,8 @@ class SkalaNumInt(PySCFNumInt[Array]):
         def is_nlc(xc: str) -> bool:
             return False
 
-    def gen_response(  # type: ignore[override]  # wider Array type than PySCF base
+    # Overrides PySCF's base with a wider Array type for mo_coeff/mo_occ.
+    def gen_response(
         self,
         mo_coeff: Array | None,
         mo_occ: Array | None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,27 +12,5 @@ from skala.functional import ExcFunctionalBase, load_functional
 
 @pytest.fixture(scope="session")
 def load_functional_cached() -> ty.Callable[..., ExcFunctionalBase | str]:
-    """Load each functional from the Hub at most once per test session.
-
-    ``load_functional`` validates the cached model file's ETag against the
-    Hugging Face Hub on every call, i.e. one network round-trip per invocation.
-    The parametrized suite would otherwise issue hundreds of these and could trip
-    the Hub's 429 rate limit.
-
-    Two pieces work together to fix this, each doing a distinct job:
-
-    - ``lru_cache`` does the actual deduplication. It memoizes by argument, so
-      each distinct ``(name, device)`` runs ``load_functional`` (and its ETag
-      check) exactly once and later calls reuse the loaded object. A plain
-      fixture cannot do this: a fixture returns a single value and takes no
-      call-time arguments, but tests need many functionals (``skala-1.0``,
-      ``skala-1.1``, ``pbe``, ...), some chosen dynamically. Caching on the
-      name lets one loader serve them all while loading each only once.
-    - ``scope="session"`` gives the cache a single instance that lives for the
-      whole run, so deduplication spans every test file (a function-scoped
-      fixture would rebuild the cache per test). The fixture also injects the
-      loader into tests via the usual dependency-injection mechanism, keeping
-      this test-only: production ``load_functional`` is unchanged and the cache
-      is discarded when the session ends.
-    """
+    """Load each functional from the Hub at most once per test session."""
     return functools.lru_cache(maxsize=None)(load_functional)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@
 """Shared test fixtures."""
 
 import functools
-import typing as ty
+from typing import Callable
 
 import pytest
 
@@ -11,6 +11,6 @@ from skala.functional import ExcFunctionalBase, load_functional
 
 
 @pytest.fixture(scope="session")
-def load_functional_cached() -> ty.Callable[..., ExcFunctionalBase | str]:
+def load_functional_cached() -> Callable[..., ExcFunctionalBase | str]:
     """Load each functional from the Hub at most once per test session."""
     return functools.lru_cache(maxsize=None)(load_functional)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@
 """Shared test fixtures."""
 
 import functools
-from typing import Callable
+from collections.abc import Callable
 
 import pytest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: MIT
+
+"""Shared test fixtures."""
+
+import functools
+import typing as ty
+
+import pytest
+
+from skala.functional import ExcFunctionalBase, load_functional
+
+
+@pytest.fixture(scope="session")
+def load_functional_cached() -> ty.Callable[..., ExcFunctionalBase | str]:
+    """Load each functional from the Hub at most once per test session.
+
+    ``load_functional`` validates the cached model file's ETag against the
+    Hugging Face Hub on every call, i.e. one network round-trip per invocation.
+    The parametrized suite would otherwise issue hundreds of these and could trip
+    the Hub's 429 rate limit.
+
+    Two pieces work together to fix this, each doing a distinct job:
+
+    - ``lru_cache`` does the actual deduplication. It memoizes by argument, so
+      each distinct ``(name, device)`` runs ``load_functional`` (and its ETag
+      check) exactly once and later calls reuse the loaded object. A plain
+      fixture cannot do this: a fixture returns a single value and takes no
+      call-time arguments, but tests need many functionals (``skala-1.0``,
+      ``skala-1.1``, ``pbe``, ...), some chosen dynamically. Caching on the
+      name lets one loader serve them all while loading each only once.
+    - ``scope="session"`` gives the cache a single instance that lives for the
+      whole run, so deduplication spans every test file (a function-scoped
+      fixture would rebuild the cache per test). The fixture also injects the
+      loader into tests via the usual dependency-injection mechanism, keeping
+      this test-only: production ``load_functional`` is unchanged and the cache
+      is discarded when the session ends.
+    """
+    return functools.lru_cache(maxsize=None)(load_functional)

--- a/tests/test_gpu4pyscf_classes.py
+++ b/tests/test_gpu4pyscf_classes.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 import pytest
 import torch

--- a/tests/test_gpu4pyscf_classes.py
+++ b/tests/test_gpu4pyscf_classes.py
@@ -1,3 +1,5 @@
+import typing as ty
+
 import pytest
 import torch
 from pyscf import gto
@@ -8,7 +10,6 @@ if not torch.cuda.is_available():
         allow_module_level=True,
     )
 
-from skala.functional import load_functional
 from skala.functional.base import ExcFunctionalBase
 from skala.gpu4pyscf import SkalaKS
 from skala.gpu4pyscf.dft import SkalaRKS, SkalaUKS
@@ -17,9 +18,12 @@ from skala.gpu4pyscf.grids import UnsortableGrids
 
 
 @pytest.fixture(params=["skala-1.0", "skala-1.1"])
-def skala_xc(request: pytest.FixtureRequest) -> ExcFunctionalBase:
+def skala_xc(
+    request: pytest.FixtureRequest,
+    load_functional_cached: ty.Callable[..., ExcFunctionalBase | str],
+) -> ExcFunctionalBase:
     """Load the Skala functional under test on GPU."""
-    func = load_functional(request.param, device=torch.device("cuda:0"))
+    func = load_functional_cached(request.param, device=torch.device("cuda:0"))
     assert isinstance(func, ExcFunctionalBase)
     return func
 

--- a/tests/test_gpu4pyscf_classes.py
+++ b/tests/test_gpu4pyscf_classes.py
@@ -1,4 +1,4 @@
-import typing as ty
+from typing import Callable
 
 import pytest
 import torch
@@ -20,7 +20,7 @@ from skala.gpu4pyscf.grids import UnsortableGrids
 @pytest.fixture(params=["skala-1.0", "skala-1.1"])
 def skala_xc(
     request: pytest.FixtureRequest,
-    load_functional_cached: ty.Callable[..., ExcFunctionalBase | str],
+    load_functional_cached: Callable[..., ExcFunctionalBase | str],
 ) -> ExcFunctionalBase:
     """Load the Skala functional under test on GPU."""
     func = load_functional_cached(request.param, device=torch.device("cuda:0"))

--- a/tests/test_gpu4pyscf_gradients.py
+++ b/tests/test_gpu4pyscf_gradients.py
@@ -12,7 +12,6 @@ if not torch.cuda.is_available():
 
 from gpu4pyscf import dft, scf
 
-from skala.functional import load_functional
 from skala.functional.base import ExcFunctionalBase
 from skala.gpu4pyscf import SkalaKS
 from skala.gpu4pyscf.gradients import (
@@ -531,10 +530,14 @@ FULL_GRAD_REF = {
 }
 
 
-def test_full_grad(mol_name: str, xc_name: str) -> None:
+def test_full_grad(
+    mol_name: str,
+    xc_name: str,
+    load_functional_cached: Callable[..., ExcFunctionalBase | str],
+) -> None:
     # analytical result
     mol = get_mol(mol_name)
-    func = load_functional(xc_name, device=torch.device("cuda:0"))
+    func = load_functional_cached(xc_name, device=torch.device("cuda:0"))
     assert isinstance(func, ExcFunctionalBase)
     # skala-1.1 uses per-atom packed grids (unsorted) and needs a denser grid
     # to avoid NaNs in the SCF.

--- a/tests/test_gpu4pyscf_gradients.py
+++ b/tests/test_gpu4pyscf_gradients.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 import pytest
 import torch
 from pyscf import gto

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -10,8 +10,8 @@ does not mutate the global RNG visible to other tests in the process.
 """
 
 import math
-import typing as ty
 from collections.abc import Iterator
+from typing import Callable
 
 import pytest
 import torch
@@ -417,7 +417,7 @@ def test_get_exc_variable_grid_sizes() -> None:
 
 
 def test_traced_functional_and_loaded_functional_are_equal(
-    load_functional_cached: ty.Callable[..., ExcFunctionalBase | str],
+    load_functional_cached: Callable[..., ExcFunctionalBase | str],
 ) -> None:
     # This test ensures that the traced functional and the loaded functional
     # give the same output for the same input.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -10,12 +10,13 @@ does not mutate the global RNG visible to other tests in the process.
 """
 
 import math
+import typing as ty
 from collections.abc import Iterator
 
 import pytest
 import torch
 
-from skala.functional import ExcFunctionalBase, load_functional
+from skala.functional import ExcFunctionalBase
 from skala.functional.model import (
     ANGSTROM_TO_BOHR,
     ExpRadialScaleModel,
@@ -415,11 +416,13 @@ def test_get_exc_variable_grid_sizes() -> None:
     )
 
 
-def test_traced_functional_and_loaded_functional_are_equal() -> None:
+def test_traced_functional_and_loaded_functional_are_equal(
+    load_functional_cached: ty.Callable[..., ExcFunctionalBase | str],
+) -> None:
     # This test ensures that the traced functional and the loaded functional
     # give the same output for the same input.
 
-    traced_model = load_functional("skala-1.1")
+    traced_model = load_functional_cached("skala-1.1")
     assert isinstance(traced_model, ExcFunctionalBase)
 
     clean_state_dict = {

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -10,8 +10,7 @@ does not mutate the global RNG visible to other tests in the process.
 """
 
 import math
-from collections.abc import Iterator
-from typing import Callable
+from collections.abc import Callable, Iterator
 
 import pytest
 import torch

--- a/tests/test_pyscf_classes.py
+++ b/tests/test_pyscf_classes.py
@@ -1,4 +1,4 @@
-import typing as ty
+from typing import Callable
 
 import pytest
 from pyscf import gto
@@ -13,7 +13,7 @@ from skala.pyscf.grids import UnsortableGrids
 @pytest.fixture(params=["skala-1.0", "skala-1.1"])
 def skala_xc(
     request: pytest.FixtureRequest,
-    load_functional_cached: ty.Callable[..., ExcFunctionalBase | str],
+    load_functional_cached: Callable[..., ExcFunctionalBase | str],
 ) -> ExcFunctionalBase:
     """Load the Skala functional under test."""
     func = load_functional_cached(request.param)
@@ -95,7 +95,7 @@ def test_skala_class(
 
 
 def test_grid_alignment_mismatch_raises(
-    load_functional_cached: ty.Callable[..., ExcFunctionalBase | str],
+    load_functional_cached: Callable[..., ExcFunctionalBase | str],
 ) -> None:
     """generate_features raises ValueError when grid has alignment padding."""
     from unittest.mock import patch

--- a/tests/test_pyscf_classes.py
+++ b/tests/test_pyscf_classes.py
@@ -1,7 +1,8 @@
+import typing as ty
+
 import pytest
 from pyscf import gto
 
-from skala.functional import load_functional
 from skala.functional.base import ExcFunctionalBase
 from skala.pyscf import SkalaKS
 from skala.pyscf.dft import SkalaRKS, SkalaUKS
@@ -10,9 +11,12 @@ from skala.pyscf.grids import UnsortableGrids
 
 
 @pytest.fixture(params=["skala-1.0", "skala-1.1"])
-def skala_xc(request: pytest.FixtureRequest) -> ExcFunctionalBase:
+def skala_xc(
+    request: pytest.FixtureRequest,
+    load_functional_cached: ty.Callable[..., ExcFunctionalBase | str],
+) -> ExcFunctionalBase:
     """Load the Skala functional under test."""
-    func = load_functional(request.param)
+    func = load_functional_cached(request.param)
     assert isinstance(func, ExcFunctionalBase)
     return func
 
@@ -90,7 +94,9 @@ def test_skala_class(
         assert isinstance(ks.grids, UnsortableGrids)
 
 
-def test_grid_alignment_mismatch_raises() -> None:
+def test_grid_alignment_mismatch_raises(
+    load_functional_cached: ty.Callable[..., ExcFunctionalBase | str],
+) -> None:
     """generate_features raises ValueError when grid has alignment padding."""
     from unittest.mock import patch
 
@@ -99,7 +105,7 @@ def test_grid_alignment_mismatch_raises() -> None:
     from skala.pyscf.features import generate_features
 
     mol = gto.M(atom="H 0 0 0; H 0 0 0.74", basis="sto-3g", verbose=0)
-    func = load_functional("skala-1.1")
+    func = load_functional_cached("skala-1.1")
     assert not isinstance(func, str)
 
     def _build_grids_keep_padding(grids: gto.Mole, mol: gto.Mole) -> gto.Mole:

--- a/tests/test_pyscf_classes.py
+++ b/tests/test_pyscf_classes.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 import pytest
 from pyscf import gto

--- a/tests/test_pyscf_gradients.py
+++ b/tests/test_pyscf_gradients.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 import pytest
 import torch
 from _ridders import num_grad_ridders

--- a/tests/test_pyscf_gradients.py
+++ b/tests/test_pyscf_gradients.py
@@ -4,7 +4,6 @@ import pytest
 import torch
 from pyscf import dft, gto, scf
 
-from skala.functional import load_functional
 from skala.functional.base import ExcFunctionalBase
 from skala.pyscf import SkalaKS
 from skala.pyscf.features import generate_features
@@ -522,10 +521,14 @@ FULL_GRAD_REF = {
 }
 
 
-def test_full_grad(mol_name: str, xc_name: str) -> None:
+def test_full_grad(
+    mol_name: str,
+    xc_name: str,
+    load_functional_cached: Callable[..., ExcFunctionalBase | str],
+) -> None:
     # analytical result
     mol = get_mol(mol_name)
-    func = load_functional(xc_name)
+    func = load_functional_cached(xc_name)
     assert isinstance(func, ExcFunctionalBase)
 
     scf = run_scf(mol, func, with_dftd3=False)

--- a/tests/test_traditional.py
+++ b/tests/test_traditional.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: MIT
 
+import typing as ty
+
 import pytest
 from pyscf import dft, gto
 from pytest import approx
 from torch import nn
 
-from skala.functional import ExcFunctionalBase, load_functional
+from skala.functional import ExcFunctionalBase
 from skala.pyscf import SkalaKS
 
 
@@ -26,9 +28,12 @@ def xc(request: pytest.FixtureRequest) -> str:
 
 
 @pytest.fixture
-def xc_fun(xc: str) -> ExcFunctionalBase:
+def xc_fun(
+    xc: str,
+    load_functional_cached: ty.Callable[..., ExcFunctionalBase | str],
+) -> ExcFunctionalBase:
     """Fixture to load the functional."""
-    func = load_functional(xc)
+    func = load_functional_cached(xc)
     assert isinstance(func, ExcFunctionalBase)
     return func
 
@@ -51,8 +56,11 @@ def test_scf(mol: gto.Mole, xc_str: str, xc_fun: ExcFunctionalBase) -> None:
 
 
 @pytest.mark.parametrize("xc_name", ["pbe", "tpss", "scan", "rscan", "r2scan"])
-def test_parameters(xc_name: str) -> None:
-    xc_fun = load_functional(xc_name)
+def test_parameters(
+    xc_name: str,
+    load_functional_cached: ty.Callable[..., ExcFunctionalBase | str],
+) -> None:
+    xc_fun = load_functional_cached(xc_name)
     assert isinstance(xc_fun, ExcFunctionalBase)
 
     expected_num_params = {
@@ -73,8 +81,11 @@ def test_parameters(xc_name: str) -> None:
 
 
 @pytest.mark.parametrize("xc_name", ["scan", "rscan", "r2scan"])
-def test_scan_constants(xc_name: str) -> None:
-    xc_fun = load_functional(xc_name)
+def test_scan_constants(
+    xc_name: str,
+    load_functional_cached: ty.Callable[..., ExcFunctionalBase | str],
+) -> None:
+    xc_fun = load_functional_cached(xc_name)
     assert isinstance(xc_fun, ExcFunctionalBase)
 
     assert approx(xc_fun.ax) == -0.7385587663820224, (

--- a/tests/test_traditional.py
+++ b/tests/test_traditional.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 
-from typing import Callable
+from collections.abc import Callable
 
 import pytest
 from pyscf import dft, gto

--- a/tests/test_traditional.py
+++ b/tests/test_traditional.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 
-import typing as ty
+from typing import Callable
 
 import pytest
 from pyscf import dft, gto
@@ -30,7 +30,7 @@ def xc(request: pytest.FixtureRequest) -> str:
 @pytest.fixture
 def xc_fun(
     xc: str,
-    load_functional_cached: ty.Callable[..., ExcFunctionalBase | str],
+    load_functional_cached: Callable[..., ExcFunctionalBase | str],
 ) -> ExcFunctionalBase:
     """Fixture to load the functional."""
     func = load_functional_cached(xc)
@@ -58,7 +58,7 @@ def test_scf(mol: gto.Mole, xc_str: str, xc_fun: ExcFunctionalBase) -> None:
 @pytest.mark.parametrize("xc_name", ["pbe", "tpss", "scan", "rscan", "r2scan"])
 def test_parameters(
     xc_name: str,
-    load_functional_cached: ty.Callable[..., ExcFunctionalBase | str],
+    load_functional_cached: Callable[..., ExcFunctionalBase | str],
 ) -> None:
     xc_fun = load_functional_cached(xc_name)
     assert isinstance(xc_fun, ExcFunctionalBase)
@@ -83,7 +83,7 @@ def test_parameters(
 @pytest.mark.parametrize("xc_name", ["scan", "rscan", "r2scan"])
 def test_scan_constants(
     xc_name: str,
-    load_functional_cached: ty.Callable[..., ExcFunctionalBase | str],
+    load_functional_cached: Callable[..., ExcFunctionalBase | str],
 ) -> None:
     xc_fun = load_functional_cached(xc_name)
     assert isinstance(xc_fun, ExcFunctionalBase)


### PR DESCRIPTION
## Problem
Tests load the Skala model via `load_functional`, which validates the cached
file's ETag against the Hugging Face Hub on **every** call. The parametrized
suite (e.g. `test_skala_class` alone expands to 32 cases in one file, each with
a function-scoped model fixture) fires hundreds of these requests in seconds and
trips the Hub's **429 Too Many Requests** rate limit, failing tests at fixture
setup.

Observed in CI:
https://github.com/microsoft/skala/actions/runs/27552110518/job/81441338451?pr=77#step:5:181

```
429 Too Many Requests for url:
https://huggingface.co/microsoft/skala-1.0/resolve/main/skala-1.0.fun
```

## Fix (test-only)
- Add a session-scoped `load_functional_cached` fixture in `tests/conftest.py`
  that wraps `load_functional` in an `lru_cache`.
- Route all test/fixture model loads through it, so each `(name, device)` is
  loaded once per session instead of once per test.

Production `load_functional` is unchanged, so ETag validation still happens,
just once per model per session.

## Verification
- `ruff format` / `ruff check` clean.
- Session fixture is created exactly once (verified via `--setup-plan`).
- `test_pyscf_classes` (33) and `test_traditional` (29) pass locally.
