### PR TITLE
temporary gpu4pyscf nuclear gradient fix

### DIFF
--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -26,4 +26,4 @@ dependencies:
   - mypy
   - pip:
     - huggingface_hub
-    - gpu4pyscf-cuda12x >=1.5,<1.8
+    - gpu4pyscf-cuda12x >=1.5,<1.7.1


### PR DESCRIPTION
From version 1.7.1 onwards gpu4pyscf replaces grids_noresponse_cc by a stub, so we constrain the maximum version as a quick fix.