### PR TITLE
fix(examples): document atomic_grid features in download_model.py

### DIFF
--- a/examples/cpp/cpp_integration/download_model.py
+++ b/examples/cpp/cpp_integration/download_model.py
@@ -16,6 +16,7 @@ from skala.functional.load import TracedFunctional
 
 GRID_SIZE = "grid_size"
 NUM_ATOMS = "num_atoms"
+MAX_GRID_PER_ATOM = "max_grid_per_atom"
 
 feature_shapes = {
     "density": [2, GRID_SIZE],
@@ -24,6 +25,23 @@ feature_shapes = {
     "grid_coords": [GRID_SIZE, 3],
     "grid_weights": [GRID_SIZE],
     "coarse_0_atomic_coords": [NUM_ATOMS, 3],
+    "atomic_grid_weights": [GRID_SIZE],
+    "atomic_grid_sizes": [NUM_ATOMS],
+    "atomic_grid_size_bound_shape": [MAX_GRID_PER_ATOM, 0],
+}
+
+# The integer dtype features below are bookkeeping for the per-atom grid layout
+# required by Skala's non-local model; they are not floating-point physical data.
+feature_dtypes = {
+    "density": "float64",
+    "kin": "float64",
+    "grad": "float64",
+    "grid_coords": "float64",
+    "grid_weights": "float64",
+    "coarse_0_atomic_coords": "float64",
+    "atomic_grid_weights": "float64",
+    "atomic_grid_sizes": "int64",
+    "atomic_grid_size_bound_shape": "int64",
 }
 
 feature_labels = {
@@ -33,6 +51,22 @@ feature_labels = {
     "grid_coords": "Coordinates of grid points",
     "grid_weights": "Weights of grid points",
     "coarse_0_atomic_coords": "Atomic coordinates",
+    # The grid is the concatenation of per-atom atomic grids, in atom-major order.
+    # atomic_grid_weights are the raw quadrature weights for integrating over each
+    # individual atomic grid, i.e. they are NOT multiplied by the Becke partition
+    # function (unlike grid_weights, which integrate the molecular energy). They are
+    # used by the non-local model as the integration measure over each atom's grid.
+    "atomic_grid_weights": "Per-atom-grid quadrature weights (not partition-weighted)",
+    "atomic_grid_sizes": "Number of grid points belonging to each atom",
+    # atomic_grid_size_bound_shape carries no data: it is an empty tensor whose first
+    # dimension equals max(atomic_grid_sizes). It exists only to pass that static
+    # padding bound as a tensor shape rather than a tensor value, which is an
+    # implementation detail required by the LibTorch/TorchScript export of the model
+    # (data-dependent output shapes are not allowed).
+    "atomic_grid_size_bound_shape": (
+        "Empty tensor whose first dim is max(atomic_grid_sizes); "
+        "TorchScript/LibTorch implementation detail"
+    ),
 }
 
 
@@ -57,7 +91,7 @@ def download_model(huggingface_repo_id: str, filename: str, output_path: str) ->
     print("\nExpected inputs:")
     for feature in fun.features:
         print(
-            f"- {feature} {feature_shapes[feature]} in float64 ({feature_labels[feature]})"
+            f"- {feature} {feature_shapes[feature]} in {feature_dtypes[feature]} ({feature_labels[feature]})"
         )
 
     print(f"\nExpected D3 dispersion settings: {fun.expected_d3_settings}\n")

--- a/tests/test_download_model.py
+++ b/tests/test_download_model.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: MIT
+
+"""Tests for the C++ integration ``download_model.py`` example script.
+
+The script keeps hand-maintained ``feature_shapes`` / ``feature_dtypes`` /
+``feature_labels`` dictionaries that document the inputs each Skala functional
+expects. These dictionaries are not exercised anywhere else, so they silently
+went stale when new features (e.g. the ``atomic_grid_*`` features used by Skala
+1.1) were added to the model. These tests run the script end to end and assert
+that every feature requested by each published functional is documented, so the
+script cannot drift out of sync again.
+"""
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from skala.functional._hashes import KNOWN_HASHES
+from skala.functional.load import TracedFunctional
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "examples"
+    / "cpp"
+    / "cpp_integration"
+    / "download_model.py"
+)
+
+# Functionals downloaded and documented by the script's ``main`` entry point.
+_PUBLISHED_FUNCTIONALS = [
+    ("microsoft/skala-1.1", "skala-1.1.fun"),
+    ("microsoft/skala-baselines", "ldax.fun"),
+]
+
+
+@pytest.fixture(scope="module")
+def script_module() -> ModuleType:
+    """Import ``download_model.py`` as a module from its file path."""
+    spec = importlib.util.spec_from_file_location("download_model", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_download_script_runs(
+    script_module: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The script runs end to end without raising.
+
+    ``main`` writes the downloaded ``.fun`` files into the current working
+    directory, so run it inside ``tmp_path``. A missing feature in any of the
+    documentation dictionaries surfaces here as a ``KeyError``.
+    """
+    monkeypatch.chdir(tmp_path)
+    script_module.main()
+
+
+@pytest.mark.parametrize("repo_id, filename", _PUBLISHED_FUNCTIONALS)
+def test_all_expected_features_are_documented(
+    script_module: ModuleType, repo_id: str, filename: str
+) -> None:
+    """Every feature a published functional requests must be documented."""
+    from huggingface_hub import hf_hub_download
+
+    path = hf_hub_download(repo_id=repo_id, filename=filename)
+    fun = TracedFunctional.load(
+        path, expected_hash=KNOWN_HASHES.get((repo_id, filename))
+    )
+
+    for feature in fun.features:
+        assert feature in script_module.feature_shapes, (
+            f"{feature!r} (required by {filename}) is missing from feature_shapes"
+        )
+        assert feature in script_module.feature_dtypes, (
+            f"{feature!r} (required by {filename}) is missing from feature_dtypes"
+        )
+        assert feature in script_module.feature_labels, (
+            f"{feature!r} (required by {filename}) is missing from feature_labels"
+        )


### PR DESCRIPTION
The `download_model.py` C++ integration example crashes with `KeyError: 'atomic_grid_weights'` when run against the current `microsoft/skala-1.1` checkpoint: the functional requests the `atomic_grid_*` features, but the script's hand-maintained `feature_shapes` / `feature_labels` dictionaries were never updated to include them. These dictionaries are the only human-readable documentation of the model inputs in the repo, and nothing exercised them, so they silently went stale.

## Changes

- Document the three per-atom grid features in `download_model.py`:
  - `atomic_grid_weights` — per-atom-grid quadrature weights (the raw weights for integrating over each individual atomic grid, **not** Becke-partition-weighted, unlike `grid_weights`).
  - `atomic_grid_sizes` — number of grid points per atom.
  - `atomic_grid_size_bound_shape` — empty tensor whose first dim is `max(atomic_grid_sizes)`; carries no data and exists only to pass the static padding bound as a tensor shape (a TorchScript/LibTorch export detail). 
- Add a `feature_dtypes` map and print per-feature dtype, since `atomic_grid_sizes` and `atomic_grid_size_bound_shape` are `int64`, not `float64`.
- Inline comments capture the fuller explanations for the two subtle features.

## Tests

Add `tests/test_download_model.py`, which:
- runs the script end to end (would catch the `KeyError` regression), and
- asserts every feature each published functional requests is present in all three documentation dictionaries, so they cannot drift out of sync again.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>