### PR TITLE
Pin pre-commit hook revision to commit SHA

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.10
+    rev: b831c3dc5d27d9da294ae4e915773b99aa24a7c5  # frozen: v0.15.10
     hooks:
       # Run the linter.
       - id: ruff


### PR DESCRIPTION
Replaces the ruff-pre-commit version tag in .pre-commit-config.yaml with the corresponding commit SHA, keeping the version as a # frozen: comment. No version change; the SHA is the commit v0.15.10 resolves to.