### PR TITLE
Fix sphinx build

### DIFF
--- a/src/skala/pyscf/numint.py
+++ b/src/skala/pyscf/numint.py
@@ -327,7 +327,7 @@ class SkalaNumInt(PySCFNumInt[Array]):
                     ks.grids,
                     features=set(self.func.features),
                     func_deriv=2,
-                    max_memory_in_mb=kwargs.get("max_memory", None)
+                    max_memory_in_mb=ks.max_memory
                     if dm0.device.type == "cpu"
                     else None,
                     safety_fraction=kwargs.get(


### PR DESCRIPTION
The sphinx build was failing due to a bug in setting `max_memory` in `gen_response` while running on cpu. This PR fixes that by correctly fetching it from the ks object instead from the kwargs dict.