### PR TITLE
Load Skala 1.1 rev1 artifacts by default

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -23,13 +23,13 @@ jobs:
 
     - name: Download checkpoint
       run: >-
-         hf download microsoft/skala-1.1 skala-1.1.fun --local-dir .
+         hf download microsoft/skala-1.1 skala-1.1-rev1.fun --local-dir .
 
     - name: Upload checkpoint
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: skala-checkpoint
-        path: skala-1.1.fun
+        path: skala-1.1-rev1.fun
 
   pt-features:
     runs-on: ubuntu-latest
@@ -153,7 +153,7 @@ jobs:
       run: >-
          Skala
          ./gauxc/tests/ref_data/onedft_he_def2qzvp_tpss_uks.hdf5
-         --model ./skala-1.1.fun
+         --model ./skala-1.1-rev1.fun
       shell: micromamba-shell {0}
 
   ftorch:
@@ -205,6 +205,6 @@ jobs:
     - name: Run example
       run: >-
          Skala
-         ./skala-1.1.fun
+         ./skala-1.1-rev1.fun
          ./features
       shell: micromamba-shell {0}

--- a/docs/ftorch.rst
+++ b/docs/ftorch.rst
@@ -182,7 +182,7 @@ To evaluate Skala, we download the model checkpoint from HuggingFace using the `
 
 .. code-block:: shell
 
-   hf download microsoft/skala-1.1 skala-1.1.fun --local-dir .
+   hf download microsoft/skala-1.1 skala-1.1-rev1.fun --local-dir .
 
 .. note::
 
@@ -203,13 +203,13 @@ And run the application, passing the path to the Skala model and the feature dir
 
 .. code-block:: bash
 
-   ./build/Skala skala-1.1.fun features
+   ./build/Skala skala-1.1-rev1.fun features
 
 The output for the H2 molecule with the def2-QZVP basis set should look like this:
 
 .. code-block:: text
 
-   [1] Loading model from ./skala-1.1.fun
+   [1] Loading model from ./skala-1.1-rev1.fun
    [2] Loading features from ./features
     -> Loading atomic_grid_size_bound_shape
     -> Loading coarse_0_atomic_coords
@@ -257,13 +257,13 @@ Finally, we can run the application again to see the updated output with the com
 
 .. code-block:: bash
 
-   ./build/Skala skala-1.1.fun features
+   ./build/Skala skala-1.1-rev1.fun features
 
 In the output we can see the computed exchange-correlation energy as well as the mean values of the potential components, and the raw tensor data for each component.
 
 .. code-block:: text
 
-   [1] Loading model from ./skala-1.1.fun
+   [1] Loading model from ./skala-1.1-rev1.fun
    [2] Loading features from ./features
     -> Loading atomic_grid_size_bound_shape
     -> Loading coarse_0_atomic_coords

--- a/docs/gauxc/c-library.rst
+++ b/docs/gauxc/c-library.rst
@@ -507,8 +507,8 @@ After downloading the model checkpoint we can run our driver again with the new 
 
 .. code-block:: shell
 
-   hf download microsoft/skala-1.1 skala-1.1.fun --local-dir .
-   ./build/Skala He_def2-svp.h5 --model ./skala-1.1.fun
+   hf download microsoft/skala-1.1 skala-1.1-rev1.fun --local-dir .
+   ./build/Skala He_def2-svp.h5 --model ./skala-1.1-rev1.fun
 
 In the output we can see the results for the Skala functional
 
@@ -516,7 +516,7 @@ In the output we can see the results for the Skala functional
 
    Configuration
    -> Input file        : He_def2-svp.h5
-   -> Model             : ./skala-1.1.fun
+   -> Model             : ./skala-1.1-rev1.fun
    -> Grid              : fine
    -> Radial quadrature : muraknowles
    -> Pruning scheme    : robust

--- a/docs/gauxc/cpp-library.rst
+++ b/docs/gauxc/cpp-library.rst
@@ -413,8 +413,8 @@ After downloading the model checkpoint we can run our driver again with the new 
 
 .. code-block:: shell
 
-   hf download microsoft/skala-1.1 skala-1.1.fun --local-dir .
-   ./build/Skala He_def2-svp.h5 --model ./skala-1.1.fun
+   hf download microsoft/skala-1.1 skala-1.1-rev1.fun --local-dir .
+   ./build/Skala He_def2-svp.h5 --model ./skala-1.1-rev1.fun
 
 In the output we can see the results for the Skala functional
 
@@ -422,7 +422,7 @@ In the output we can see the results for the Skala functional
 
    Configuration
    -> Input file        : He_def2-svp.h5
-   -> Model             : ./skala-1.1.fun
+   -> Model             : ./skala-1.1-rev1.fun
    -> Grid              : fine
    -> Radial quadrature : muraknowles
    -> Pruning scheme    : robust

--- a/docs/gauxc/fortran-library.rst
+++ b/docs/gauxc/fortran-library.rst
@@ -560,8 +560,8 @@ from the ``huggingface_hub`` package:
 
 .. code-block:: shell
 
-   hf download microsoft/skala-1.1 skala-1.1.fun --local-dir .
-   ./build/Skala He_def2-svp.h5 --model ./skala-1.1.fun
+   hf download microsoft/skala-1.1 skala-1.1-rev1.fun --local-dir .
+   ./build/Skala He_def2-svp.h5 --model ./skala-1.1-rev1.fun
 
 The output shows results for the Skala functional:
 
@@ -569,7 +569,7 @@ The output shows results for the Skala functional:
 
    Configuration
    -> Input file        : He_def2-svp.h5
-   -> Model             : ./skala-1.1.fun
+   -> Model             : ./skala-1.1-rev1.fun
    -> Grid              : fine
    -> Radial quadrature : muraknowles
    -> Pruning scheme    : robust

--- a/examples/cpp/cpp_integration/README.md
+++ b/examples/cpp/cpp_integration/README.md
@@ -42,7 +42,7 @@ python ./prepare_inputs.py --output-dir H2
 Finally, run $E_\text{xc}$ and (partial) $V_\text{xc}$ computations with the C++ example:
 
 ```bash
-./_build/skala_cpp_integration skala-1.1.fun H2
+./_build/skala_cpp_integration skala-1.1-rev1.fun H2
 ```
 
 **Note:** You are expected to add D3 dispersion correction (using b3lyp settings) to the final energy of Skala.

--- a/examples/cpp/cpp_integration/download_model.py
+++ b/examples/cpp/cpp_integration/download_model.py
@@ -72,7 +72,7 @@ feature_labels = {
 
 def main() -> None:
     for huggingface_repo_id, filename in (
-        ("microsoft/skala-1.1", "skala-1.1.fun"),
+        ("microsoft/skala-1.1", "skala-1.1-rev1.fun"),
         ("microsoft/skala-baselines", "ldax.fun"),
     ):
         output_path = filename.split("/")[-1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skala"
-version = "2026.7"
+version = "2026.8"
 description = "Skala Exchange Correlation Functional"
 authors = []
 license-files = ["LICENSE.txt"]

--- a/src/skala/functional/__init__.py
+++ b/src/skala/functional/__init__.py
@@ -45,7 +45,9 @@ __all__ = [
 
 _SKALA_VERSIONS = {
     "skala-1.0": ("skala-1.0.fun", "skala-1.0-cuda.fun"),
-    "skala-1.1": ("skala-1.1.fun", "skala-1.1-cuda.fun"),
+    "skala-1.1": ("skala-1.1-rev1.fun", "skala-1.1-rev1-cuda.fun"),
+    "skala-1.1-rev0": ("skala-1.1.fun", "skala-1.1-cuda.fun"),
+    "skala-1.1-rev1": ("skala-1.1-rev1.fun", "skala-1.1-rev1-cuda.fun"),
 }
 
 
@@ -58,6 +60,8 @@ def load_functional(
         name: Name of the functional. Skala-native values:
 
             - ``"skala-1.1"``: Skala 1.1 neural functional (recommended).
+            - ``"skala-1.1-rev1"``: Skala 1.1 pinned to revision 1.
+            - ``"skala-1.1-rev0"``: Skala 1.1 pinned to the original revision.
             - ``"skala-1.0"``: Skala 1.0 neural functional (legacy, traced only).
             - ``"lda"``: Local Density Approximation.
             - ``"spw92"``: SPW92 (LDA with PW92 correlation).
@@ -106,7 +110,7 @@ def load_functional(
             device_type = (
                 torch.get_default_device().type if device is None else device.type
             )
-            repo_id = f"microsoft/{func_name}"
+            repo_id = f"microsoft/{func_name.partition('-rev')[0]}"
             cpu_file, cuda_file = _SKALA_VERSIONS[func_name]
             filename = cpu_file if device_type == "cpu" else cuda_file
             path = hf_hub_download(repo_id=repo_id, filename=filename)

--- a/src/skala/functional/_hashes.py
+++ b/src/skala/functional/_hashes.py
@@ -8,23 +8,19 @@ These hashes are used to verify file integrity before loading with
 security-sensitive.
 """
 
-# Maps (repo_id, filename) -> accepted SHA-256 hex digests.
-KNOWN_HASHES: dict[tuple[str, str], tuple[str, ...]] = {
+# Maps (repo_id, filename) -> expected SHA-256 hex digest.
+KNOWN_HASHES: dict[tuple[str, str], str] = {
     ("microsoft/skala-1.0", "skala-1.0.fun"): (
-        "08d94436995937eb57c451af7c92e2c7f9e1bff6b7da029a3887e9f9dd4581c0",
+        "08d94436995937eb57c451af7c92e2c7f9e1bff6b7da029a3887e9f9dd4581c0"
     ),
     ("microsoft/skala-1.0", "skala-1.0-cuda.fun"): (
-        "0b38e13237cec771fed331664aace42f8c0db8f15caca6a5c563085e61e2b1fd",
+        "0b38e13237cec771fed331664aace42f8c0db8f15caca6a5c563085e61e2b1fd"
     ),
     ("microsoft/skala-1.1", "skala-1.1.fun"): (
-        "0c8432ac3f03c8f1276372df9aca5b7ee7f8939d47a8789eb158976e89aa0606",
-        "7f3e8622e1eb520ccd88a55464c3e359ac4d7e5ccbd1fb77a26afa1e1c20a5cd",
+        "0c8432ac3f03c8f1276372df9aca5b7ee7f8939d47a8789eb158976e89aa0606"
     ),
     (
         "microsoft/skala-1.1",
         "skala-1.1-cuda.fun",
-    ): (
-        "f77be6002d873c0a2384b6df7850d32bbec519036344ff5fdde9730c6f9a4326",
-        "f848eae769dca91741a518ae7275d10caac398ab21db649f91bc1f136872f223",
-    ),
+    ): "f77be6002d873c0a2384b6df7850d32bbec519036344ff5fdde9730c6f9a4326",
 }

--- a/src/skala/functional/_hashes.py
+++ b/src/skala/functional/_hashes.py
@@ -23,4 +23,12 @@ KNOWN_HASHES: dict[tuple[str, str], str] = {
         "microsoft/skala-1.1",
         "skala-1.1-cuda.fun",
     ): "f77be6002d873c0a2384b6df7850d32bbec519036344ff5fdde9730c6f9a4326",
+    (
+        "microsoft/skala-1.1",
+        "skala-1.1-rev1.fun",
+    ): "7f3e8622e1eb520ccd88a55464c3e359ac4d7e5ccbd1fb77a26afa1e1c20a5cd",
+    (
+        "microsoft/skala-1.1",
+        "skala-1.1-rev1-cuda.fun",
+    ): "f848eae769dca91741a518ae7275d10caac398ab21db649f91bc1f136872f223",
 }

--- a/src/skala/functional/load.py
+++ b/src/skala/functional/load.py
@@ -8,7 +8,7 @@ import hashlib
 import io
 import json
 import os
-from collections.abc import Collection, Iterable, Mapping
+from collections.abc import Iterable, Mapping
 from typing import IO, Any, cast
 
 import torch
@@ -80,16 +80,15 @@ class TracedFunctional(ExcFunctionalBase):
         fp: str | os.PathLike[str] | IO[bytes],
         device: torch.device | None = None,
         *,
-        expected_hash: str | Collection[str] | None = None,
+        expected_hash: str | None = None,
     ) -> "TracedFunctional":
         """Load a traced functional from a file.
 
         Args:
             fp: File path or readable binary stream.
             device: Target device for the loaded model.
-            expected_hash: If provided, a SHA-256 hex digest or collection of
-                accepted digests that the file content must match. A ``ValueError``
-                is raised on mismatch.
+            expected_hash: If provided, the SHA-256 hex digest that the file
+                content must match. A ``ValueError`` is raised on mismatch.
         """
         extra_files = {
             "metadata": b"",
@@ -102,11 +101,6 @@ class TracedFunctional(ExcFunctionalBase):
             device = torch.get_default_device()
 
         if expected_hash is not None:
-            expected_hashes = (
-                (expected_hash,)
-                if isinstance(expected_hash, str)
-                else tuple(expected_hash)
-            )
             # Read the whole file into memory so we can hash it before
             # passing it to the unsafe torch.jit.load deserializer.
             if isinstance(fp, (str, os.PathLike)):
@@ -116,15 +110,10 @@ class TracedFunctional(ExcFunctionalBase):
                 # Assume a file-like object
                 data = fp.read()
             actual_hash = hashlib.sha256(data).hexdigest()
-            if actual_hash not in expected_hashes:
-                expected = (
-                    expected_hashes[0]
-                    if len(expected_hashes) == 1
-                    else f"one of {', '.join(expected_hashes)}"
-                )
+            if actual_hash != expected_hash:
                 raise ValueError(
                     f"Hash mismatch for functional file: "
-                    f"expected {expected}, got {actual_hash}. "
+                    f"expected {expected_hash}, got {actual_hash}. "
                     f"The file may have been tampered with."
                 )
             fp = io.BytesIO(data)

--- a/src/skala/functional/model.py
+++ b/src/skala/functional/model.py
@@ -736,11 +736,16 @@ class TensorProduct(nn.Module):
             xw = xw * distance_weights  # broadcasts over B
         # Flatten instruction & channel dims: (B, s, r, w) -> (s, r, B*w)
         xw_flat = xw.permute(1, 2, 0, 3).reshape(xw.shape[1], xw.shape[2], -1)
-        return (
-            xw_flat[:, :, self._tp_down_xw_idx]
-            * x2[:, :, self._tp_down_sph_idx]
-            * self._tp_down_norm.to(x2.dtype)
+        # Use explicit gather to avoid Inductor miscompile observed with advanced indexing.
+        idx_xw = self._tp_down_xw_idx.view(1, 1, -1).expand(
+            xw_flat.shape[0], xw_flat.shape[1], -1
         )
+        idx_x2 = self._tp_down_sph_idx.view(1, 1, -1).expand(
+            x2.shape[0], x2.shape[1], -1
+        )
+        xw_sel = torch.gather(xw_flat, dim=2, index=idx_xw)
+        x2_sel = torch.gather(x2, dim=2, index=idx_x2)
+        return xw_sel * x2_sel * self._tp_down_norm.to(x2.dtype)
 
     def _forward_batched_tp_up(
         self,

--- a/src/skala/functional/model.py
+++ b/src/skala/functional/model.py
@@ -736,16 +736,11 @@ class TensorProduct(nn.Module):
             xw = xw * distance_weights  # broadcasts over B
         # Flatten instruction & channel dims: (B, s, r, w) -> (s, r, B*w)
         xw_flat = xw.permute(1, 2, 0, 3).reshape(xw.shape[1], xw.shape[2], -1)
-        # Use explicit gather to avoid Inductor miscompile observed with advanced indexing.
-        idx_xw = self._tp_down_xw_idx.view(1, 1, -1).expand(
-            xw_flat.shape[0], xw_flat.shape[1], -1
+        return (
+            xw_flat[:, :, self._tp_down_xw_idx]
+            * x2[:, :, self._tp_down_sph_idx]
+            * self._tp_down_norm.to(x2.dtype)
         )
-        idx_x2 = self._tp_down_sph_idx.view(1, 1, -1).expand(
-            x2.shape[0], x2.shape[1], -1
-        )
-        xw_sel = torch.gather(xw_flat, dim=2, index=idx_xw)
-        x2_sel = torch.gather(x2, dim=2, index=idx_x2)
-        return xw_sel * x2_sel * self._tp_down_norm.to(x2.dtype)
 
     def _forward_batched_tp_up(
         self,

--- a/tests/test_download_model.py
+++ b/tests/test_download_model.py
@@ -30,7 +30,7 @@ _SCRIPT_PATH = (
 
 # Functionals downloaded and documented by the script's ``main`` entry point.
 _PUBLISHED_FUNCTIONALS = [
-    ("microsoft/skala-1.1", "skala-1.1.fun"),
+    ("microsoft/skala-1.1", "skala-1.1-rev1.fun"),
     ("microsoft/skala-baselines", "ldax.fun"),
 ]
 

--- a/tests/test_hash_pinning.py
+++ b/tests/test_hash_pinning.py
@@ -53,16 +53,6 @@ def test_load_with_correct_hash(dummy_fun_bytes: bytes) -> None:
     assert isinstance(func, TracedFunctional)
 
 
-def test_load_with_one_of_multiple_hashes(dummy_fun_bytes: bytes) -> None:
-    """Loading succeeds when any accepted hash matches."""
-    correct_hash = hashlib.sha256(dummy_fun_bytes).hexdigest()
-    func = TracedFunctional.load(
-        io.BytesIO(dummy_fun_bytes),
-        expected_hash=("0" * 64, correct_hash),
-    )
-    assert isinstance(func, TracedFunctional)
-
-
 def test_load_with_wrong_hash(dummy_fun_bytes: bytes) -> None:
     """Loading raises ValueError when the hash does not match."""
     wrong_hash = "0" * 64


### PR DESCRIPTION
Use new skala-1.1-rev1 checkpoints.

Instead of the previous approach where we allow multiple hashes (old and new) for the same skala-1.1 functional, the files are now stored with a `-rev1` suffix.

Resolving now works like

```
_SKALA_VERSIONS = {
    "skala-1.0": ("skala-1.0.fun", "skala-1.0-cuda.fun"),
    "skala-1.1": ("skala-1.1-rev1.fun", "skala-1.1-rev1-cuda.fun"),
    "skala-1.1-rev0": ("skala-1.1.fun", "skala-1.1-cuda.fun"),
    "skala-1.1-rev1": ("skala-1.1-rev1.fun", "skala-1.1-rev1-cuda.fun"),
}
```