### PR TITLE
Implement own use_torch_mempool_in_cupy

### DIFF
--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -26,5 +26,4 @@ dependencies:
   - mypy
   - pip:
     - huggingface_hub
-    - pytorch-pfn-extras
     - gpu4pyscf-cuda12x >=1.6,<1.8,!=1.7.1,!=1.7.2

--- a/src/skala/gpu4pyscf/__init__.py
+++ b/src/skala/gpu4pyscf/__init__.py
@@ -31,14 +31,13 @@ except ModuleNotFoundError as e:
         "GPU4PySCF is not installed. Please install it with `pip install gpu4pyscf`."
     ) from e
 
-from skala.gpu4pyscf.torch_allocator import use_torch_mempool_in_cupy  # noqa: I001
-
-use_torch_mempool_in_cupy()
-
 from pyscf import gto
 
 from skala.functional import ExcFunctionalBase, load_functional
 from skala.gpu4pyscf import dft
+from skala.gpu4pyscf.torch_allocator import use_torch_mempool_in_cupy
+
+use_torch_mempool_in_cupy()
 
 
 def SkalaKS(

--- a/src/skala/gpu4pyscf/__init__.py
+++ b/src/skala/gpu4pyscf/__init__.py
@@ -37,6 +37,8 @@ from skala.functional import ExcFunctionalBase, load_functional
 from skala.gpu4pyscf import dft
 from skala.gpu4pyscf.torch_allocator import use_torch_mempool_in_cupy
 
+# Install this last because GPU4PySCF configures its own CuPy allocator during import.
+# Subsequent CuPy allocations use PyTorch's caching allocator
 use_torch_mempool_in_cupy()
 
 

--- a/src/skala/gpu4pyscf/__init__.py
+++ b/src/skala/gpu4pyscf/__init__.py
@@ -31,26 +31,9 @@ except ModuleNotFoundError as e:
         "GPU4PySCF is not installed. Please install it with `pip install gpu4pyscf`."
     ) from e
 
-try:
-    import pytorch_pfn_extras
-except ModuleNotFoundError as e:
-    if e.name != "pytorch_pfn_extras":
-        raise
+from skala.gpu4pyscf.torch_allocator import use_torch_mempool_in_cupy  # noqa: I001
 
-    import warnings
-
-    warnings.warn(
-        "pytorch_pfn_extras is not installed. This may lead to additional memory usage. "
-        "Please install it with `pip install pytorch-pfn-extras`.",
-        stacklevel=2,
-    )
-
-    # Reset the default CuPy memory allocator to avoid memory leak issues
-    # that seem to arise when combining the custom allocator of gpu4pyscf with DLPack usage.
-    cupy.cuda.set_allocator(cupy.get_default_memory_pool().malloc)
-else:
-    pytorch_pfn_extras.cuda.use_torch_mempool_in_cupy()
-
+use_torch_mempool_in_cupy()
 
 from pyscf import gto
 

--- a/src/skala/gpu4pyscf/dft.py
+++ b/src/skala/gpu4pyscf/dft.py
@@ -62,9 +62,6 @@ from gpu4pyscf import dft
 from gpu4pyscf.df import df_jk
 from pyscf import gto
 
-# Set the default CuPy memory allocator to avoid memory leak issues
-cp.cuda.set_allocator(cp.get_default_memory_pool().malloc)
-
 from skala.functional.base import ExcFunctionalBase
 from skala.gpu4pyscf.gradients import SkalaRKSGradient, SkalaUKSGradient
 from skala.gpu4pyscf.grids import UnsortableGrids

--- a/src/skala/gpu4pyscf/torch_allocator.py
+++ b/src/skala/gpu4pyscf/torch_allocator.py
@@ -1,4 +1,9 @@
 # SPDX-License-Identifier: MIT
+"""Use torch allocator in CuPy.
+
+Adapted from pytorch_pfn_extras.
+https://github.com/pfnet/pytorch-pfn-extras/blob/master/pytorch_pfn_extras/cuda/_allocator.py
+"""
 
 from typing import Any
 
@@ -11,9 +16,20 @@ _allocator = None
 def use_torch_mempool_in_cupy() -> None:
     """Use the PyTorch memory pool in CuPy.
 
-    If you want to use PyTorch's memory pool and non-default CUDA streams,
-    streams must be created and managed using PyTorch (using
-    `torch.cuda.Stream()` and `pytorch_pfn_extras.cuda.stream(stream)`).
+    If non-default streams are used in PyTorch and CuPy,
+    the current stream must be set to the same stream in both libraries
+    before calling this function.
+
+    Example:
+        >>> torch_stream = torch.cuda.Stream()
+        >>> cupy_stream = cupy.cuda.ExternalStream(
+        ...     torch_stream.cuda_stream,
+        ...     device_id=torch_stream.device.index,
+        ... )
+        >>> with torch.cuda.stream(torch_stream), cupy_stream:
+        ...     use_torch_mempool_in_cupy()
+        ...     torch_array = torch.ones(10, device=torch_stream.device)
+        ...     cupy_array = cupy.ones(10)
     """
     global _allocator
 
@@ -22,7 +38,13 @@ def use_torch_mempool_in_cupy() -> None:
 
 
 def _torch_alloc(size: int, device_id: int) -> Any:
-    torch_stream_ptr = torch.cuda.current_stream().cuda_stream
+    torch_stream = torch.cuda.current_stream(device_id)
+    if torch_stream.device.index != device_id:
+        raise RuntimeError(
+            "The current PyTorch stream must match the allocation device."
+        )
+
+    torch_stream_ptr = torch_stream.cuda_stream
     cupy_stream_ptr = cupy.cuda.get_current_stream().ptr
     if torch_stream_ptr != cupy_stream_ptr:
         raise RuntimeError("The current stream set in PyTorch and CuPy must be same.")

--- a/src/skala/gpu4pyscf/torch_allocator.py
+++ b/src/skala/gpu4pyscf/torch_allocator.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 from typing import Any
 
 import cupy

--- a/src/skala/gpu4pyscf/torch_allocator.py
+++ b/src/skala/gpu4pyscf/torch_allocator.py
@@ -38,13 +38,7 @@ def use_torch_mempool_in_cupy() -> None:
 
 
 def _torch_alloc(size: int, device_id: int) -> Any:
-    torch_stream = torch.cuda.current_stream(device_id)
-    if torch_stream.device.index != device_id:
-        raise RuntimeError(
-            "The current PyTorch stream must match the allocation device."
-        )
-
-    torch_stream_ptr = torch_stream.cuda_stream
+    torch_stream_ptr = torch.cuda.current_stream(device_id).cuda_stream
     cupy_stream_ptr = cupy.cuda.get_current_stream().ptr
     if torch_stream_ptr != cupy_stream_ptr:
         raise RuntimeError("The current stream set in PyTorch and CuPy must be same.")

--- a/src/skala/gpu4pyscf/torch_allocator.py
+++ b/src/skala/gpu4pyscf/torch_allocator.py
@@ -1,0 +1,31 @@
+from typing import Any
+
+import cupy
+import torch
+
+_allocator = None
+
+
+def use_torch_mempool_in_cupy() -> None:
+    """Use the PyTorch memory pool in CuPy.
+
+    If you want to use PyTorch's memory pool and non-default CUDA streams,
+    streams must be created and managed using PyTorch (using
+    `torch.cuda.Stream()` and `pytorch_pfn_extras.cuda.stream(stream)`).
+    """
+    global _allocator
+
+    _allocator = cupy.cuda.memory.PythonFunctionAllocator(_torch_alloc, _torch_free)
+    cupy.cuda.set_allocator(_allocator.malloc)
+
+
+def _torch_alloc(size: int, device_id: int) -> Any:
+    torch_stream_ptr = torch.cuda.current_stream().cuda_stream
+    cupy_stream_ptr = cupy.cuda.get_current_stream().ptr
+    if torch_stream_ptr != cupy_stream_ptr:
+        raise RuntimeError("The current stream set in PyTorch and CuPy must be same.")
+    return torch.cuda.caching_allocator_alloc(size, device_id, torch_stream_ptr)
+
+
+def _torch_free(mem_ptr: int, device_id: int) -> None:
+    torch.cuda.caching_allocator_delete(mem_ptr)  # type: ignore[no-untyped-call]

--- a/src/skala/gpu4pyscf/torch_allocator.py
+++ b/src/skala/gpu4pyscf/torch_allocator.py
@@ -21,10 +21,10 @@ def use_torch_mempool_in_cupy() -> None:
     before calling this function.
 
     Example:
-        >>> torch_stream = torch.cuda.Stream()
-        >>> cupy_stream = cupy.cuda.ExternalStream(
-        ...     torch_stream.cuda_stream,
-        ...     device_id=torch_stream.device.index,
+        >>> cupy_stream = cupy.cuda.Stream(non_blocking=True)
+        >>> torch_stream = torch.cuda.ExternalStream(
+        ...     cupy_stream.ptr,
+        ...     device=cupy_stream.device_id,
         ... )
         >>> with torch.cuda.stream(torch_stream), cupy_stream:
         ...     use_torch_mempool_in_cupy()

--- a/src/skala/pyscf/backend.py
+++ b/src/skala/pyscf/backend.py
@@ -35,10 +35,6 @@ if TYPE_CHECKING:
     Array = TypeVar("Array", np.ndarray, cupy.ndarray)
     Grid: TypeAlias = dft.Grids | dft_gpu.Grids
     KS: TypeAlias = dft.rks.RKS | dft.uks.UKS | dft_gpu.rks.RKS | dft_gpu.uks.UKS
-
-    # Reset the default CuPy memory allocator to avoid memory leak issues
-    # that seem to arise when combining the custom allocator of gpu4pyscf with DLPack usage.
-    cupy.cuda.set_allocator(cupy.get_default_memory_pool().malloc)
 else:
     try:
         import cupy
@@ -48,9 +44,6 @@ else:
         Grid: TypeAlias = dft.Grids | dft_gpu.Grids
         KS: TypeAlias = dft.rks.RKS | dft.uks.UKS | dft_gpu.rks.RKS | dft_gpu.uks.UKS
 
-        # Reset the default CuPy memory allocator to avoid memory leak issues
-        # that seem to arise when combining the custom allocator of gpu4pyscf with DLPack usage.
-        cupy.cuda.set_allocator(cupy.get_default_memory_pool().malloc)
         GPU_EXCEPTION = None
     except ImportError as e:
         GPU_EXCEPTION = e

--- a/src/skala/pyscf/numint.py
+++ b/src/skala/pyscf/numint.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: MIT
 
 from collections.abc import Callable
-from typing import Any, Protocol
+from typing import Any, Generic, Protocol
 
-import numpy as np
 import torch
 from pyscf import dft, gto
 from torch import Tensor
@@ -32,9 +31,7 @@ class LibXCSpec(Protocol):
     def is_nlc(xc: str) -> bool: ...
 
 
-class PySCFNumInt(
-    Protocol[Array],
-):
+class PySCFNumInt(Protocol, Generic[Array]):
     """Interface for PySCF-compatible numint functionals."""
 
     libxc: LibXCSpec
@@ -79,7 +76,7 @@ class PySCFNumInt(
         *,
         ks: KS,
         **kwargs: Any,
-    ) -> Callable[[np.ndarray], np.ndarray]:
+    ) -> Callable[[Array], Array]:
         """Generates the response function for the functional."""
         ...
 

--- a/tests/test_gpu4pyscf_gradients.py
+++ b/tests/test_gpu4pyscf_gradients.py
@@ -40,6 +40,29 @@ def test_torch_allocator_is_active_after_import() -> None:
     )
 
 
+def test_torch_allocator_uses_shared_non_default_stream() -> None:
+    torch_stream = torch.cuda.Stream()  # type: ignore[no-untyped-call]
+    cupy_stream = cupy.cuda.ExternalStream(
+        torch_stream.cuda_stream,
+        device_id=torch_stream.device.index,
+    )
+
+    with torch.cuda.stream(torch_stream), cupy_stream:
+        torch_allocator.use_torch_mempool_in_cupy()
+        array = cupy.empty(1)
+
+    assert array.device.id == torch_stream.device.index
+
+
+def test_torch_allocator_rejects_mismatched_streams() -> None:
+    torch_stream = torch.cuda.Stream()  # type: ignore[no-untyped-call]
+
+    with torch.cuda.stream(torch_stream), cupy.cuda.Stream.null:
+        torch_allocator.use_torch_mempool_in_cupy()
+        with pytest.raises(RuntimeError, match="must be same"):
+            cupy.empty(1)
+
+
 @pytest.fixture(params=["HF", "H2O", "H2O+"])
 def mol_name(request: pytest.FixtureRequest) -> str:
     return request.param

--- a/tests/test_gpu4pyscf_gradients.py
+++ b/tests/test_gpu4pyscf_gradients.py
@@ -34,8 +34,7 @@ from skala.pyscf.features import generate_features
 
 def test_torch_allocator_is_active_after_import() -> None:
     assert torch_allocator._allocator is not None
-    assert cupy.cuda.get_allocator() == torch_allocator._allocator.malloc
-
+    assert getattr(cupy.cuda.get_allocator(), "__self__", None) is torch_allocator._allocator
 
 @pytest.fixture(params=["HF", "H2O", "H2O+"])
 def mol_name(request: pytest.FixtureRequest) -> str:

--- a/tests/test_gpu4pyscf_gradients.py
+++ b/tests/test_gpu4pyscf_gradients.py
@@ -34,7 +34,11 @@ from skala.pyscf.features import generate_features
 
 def test_torch_allocator_is_active_after_import() -> None:
     assert torch_allocator._allocator is not None
-    assert getattr(cupy.cuda.get_allocator(), "__self__", None) is torch_allocator._allocator
+    assert (
+        getattr(cupy.cuda.get_allocator(), "__self__", None)
+        is torch_allocator._allocator
+    )
+
 
 @pytest.fixture(params=["HF", "H2O", "H2O+"])
 def mol_name(request: pytest.FixtureRequest) -> str:

--- a/tests/test_gpu4pyscf_gradients.py
+++ b/tests/test_gpu4pyscf_gradients.py
@@ -16,14 +16,6 @@ except ModuleNotFoundError:
         allow_module_level=True,
     )
 
-try:
-    import pytorch_pfn_extras
-except ModuleNotFoundError:
-    pytest.skip(
-        "Skipping gpu4pyscf gradients tests, because pytorch_pfn_extras is not installed.",
-        allow_module_level=True,
-    )
-
 from _ridders import num_grad_ridders
 from gpu4pyscf import dft, scf
 from pyscf import gto
@@ -37,6 +29,7 @@ from skala.gpu4pyscf.gradients import (
     nuc_grad_from_veff,
     veff_and_expl_nuc_grad,
 )
+from skala.gpu4pyscf.torch_allocator import use_torch_mempool_in_cupy
 from skala.pyscf.features import generate_features
 
 
@@ -492,7 +485,7 @@ def test_cuda_allocator_smoke() -> None:
         cupy.get_default_memory_pool().free_all_blocks()
 
         if mode == "pfn":
-            pytorch_pfn_extras.cuda.use_torch_mempool_in_cupy()
+            use_torch_mempool_in_cupy()
         elif mode == "cupy":
             cupy.cuda.set_allocator(cupy.get_default_memory_pool().malloc)
         else:
@@ -528,8 +521,9 @@ def test_cuda_allocator_smoke() -> None:
         return signature, peak_device_used
 
     cupy_signature, cupy_peak_device = run_mode("cupy")
-    pfn_signature, pfn_peak_device = run_mode("pfn")
+    torch_signature, torch_peak_device = run_mode("pfn")
 
-    assert pfn_signature == pytest.approx(cupy_signature, rel=1e-10, abs=1e-8)
-    assert pfn_peak_device > 0
+    assert torch_signature == pytest.approx(cupy_signature, rel=1e-10, abs=1e-8)
+    assert torch_peak_device > 0
     assert cupy_peak_device > 0
+    assert torch_peak_device < cupy_peak_device

--- a/tests/test_gpu4pyscf_gradients.py
+++ b/tests/test_gpu4pyscf_gradients.py
@@ -41,10 +41,10 @@ def test_torch_allocator_is_active_after_import() -> None:
 
 
 def test_torch_allocator_uses_shared_non_default_stream() -> None:
-    torch_stream = torch.cuda.Stream()  # type: ignore[no-untyped-call]
-    cupy_stream = cupy.cuda.ExternalStream(
-        torch_stream.cuda_stream,
-        device_id=torch_stream.device.index,
+    cupy_stream = cupy.cuda.Stream(non_blocking=True)
+    torch_stream = torch.cuda.ExternalStream(  # type: ignore[no-untyped-call]
+        cupy_stream.ptr,
+        device=cupy_stream.device_id,
     )
 
     with torch.cuda.stream(torch_stream), cupy_stream:

--- a/tests/test_gpu4pyscf_gradients.py
+++ b/tests/test_gpu4pyscf_gradients.py
@@ -22,15 +22,19 @@ from pyscf import gto
 from test_pyscf_gradients import FULL_GRAD_REF
 
 from skala.functional.base import ExcFunctionalBase
-from skala.gpu4pyscf import SkalaKS
+from skala.gpu4pyscf import SkalaKS, torch_allocator
 from skala.gpu4pyscf.gradients import (
     SkalaRKSGradient,
     SkalaUKSGradient,
     nuc_grad_from_veff,
     veff_and_expl_nuc_grad,
 )
-from skala.gpu4pyscf.torch_allocator import use_torch_mempool_in_cupy
 from skala.pyscf.features import generate_features
+
+
+def test_torch_allocator_is_active_after_import() -> None:
+    assert torch_allocator._allocator is not None
+    assert cupy.cuda.get_allocator() == torch_allocator._allocator.malloc
 
 
 @pytest.fixture(params=["HF", "H2O", "H2O+"])
@@ -456,74 +460,3 @@ def test_cuda_kernel_memory_stability() -> None:
         "CUDA kernel memory use appears unstable across repeated calls. "
         f"Observed growth: {max_growth_bytes / 1024**2:.2f} MiB"
     )
-
-
-def test_cuda_allocator_smoke() -> None:
-    """Smoke test that both allocator modes stay numerically consistent."""
-
-    mol = mol_min_bas("HF")
-
-    class TestFunc(ExcFunctionalBase):
-        def __init__(self) -> None:
-            super().__init__()
-            self.features = ["grad", "grid_weights"]
-
-        def get_exc(self, mol: dict[str, torch.Tensor]) -> torch.Tensor:
-            return (
-                (mol["grad"] ** 2 @ mol["grid_weights"])
-                @ torch.tensor(
-                    [1.0, 2.0, 3.0],
-                    dtype=torch.float64,
-                    device=mol["grad"].device,
-                )
-            ).sum()
-
-    def run_mode(mode: str) -> tuple[float, int]:
-        cupy.cuda.set_allocator(cupy.get_default_memory_pool().malloc)
-        torch.cuda.synchronize()
-        torch.cuda.empty_cache()
-        cupy.get_default_memory_pool().free_all_blocks()
-
-        if mode == "pfn":
-            use_torch_mempool_in_cupy()
-        elif mode == "cupy":
-            cupy.cuda.set_allocator(cupy.get_default_memory_pool().malloc)
-        else:
-            raise ValueError(f"Unknown allocator mode: {mode}")
-
-        grid, rdm1 = get_grid_and_rdm1(mol)
-        exc_test = TestFunc()
-
-        for _ in range(2):
-            veff = veff_and_expl_nuc_grad(
-                exc_test, mol, grid, rdm1, nuc_grad_feats={"grad"}
-            )[0]
-            _ = 2 * nuc_grad_from_veff(mol, veff, rdm1)
-
-        torch.cuda.synchronize()
-        torch.cuda.empty_cache()
-        torch.cuda.reset_peak_memory_stats()
-
-        signature = 0.0
-        peak_device_used = 0
-        for _ in range(2):
-            veff = veff_and_expl_nuc_grad(
-                exc_test, mol, grid, rdm1, nuc_grad_feats={"grad"}
-            )[0]
-            grad = 2 * nuc_grad_from_veff(mol, veff, rdm1)
-            signature += float(grad.detach().double().sum().item())
-            free_b, total_b = cupy.cuda.runtime.memGetInfo()
-            peak_device_used = max(peak_device_used, int(total_b - free_b))
-
-        torch.cuda.synchronize()
-        free_f, total_f = cupy.cuda.runtime.memGetInfo()
-        peak_device_used = max(peak_device_used, int(total_f - free_f))
-        return signature, peak_device_used
-
-    cupy_signature, cupy_peak_device = run_mode("cupy")
-    torch_signature, torch_peak_device = run_mode("pfn")
-
-    assert torch_signature == pytest.approx(cupy_signature, rel=1e-10, abs=1e-8)
-    assert torch_peak_device > 0
-    assert cupy_peak_device > 0
-    assert torch_peak_device < cupy_peak_device


### PR DESCRIPTION
Implements 
https://github.com/microsoft/skala/pull/96/changes#r3655223051

This allows us to only use the toch allocator globally. We thus do not have to reset allocators or have problems with dlpack as it all stays with the torch allocator.