### PR TITLE
Make sure gpu4pyscf allocator is never used

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,6 @@ detect-same-package = true
 line-length = 100
 
 [tool.pytest.ini_options]
-testpaths = ["tests"]
 filterwarnings = [
     "error",
     # PyTorch 2.11 deprecated `torch.jit.load`; Skala's pretrained checkpoints

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ detect-same-package = true
 line-length = 100
 
 [tool.pytest.ini_options]
+testpaths = ["tests"]
 filterwarnings = [
     "error",
     # PyTorch 2.11 deprecated `torch.jit.load`; Skala's pretrained checkpoints

--- a/src/skala/conftest.py
+++ b/src/skala/conftest.py
@@ -13,6 +13,7 @@ their own ``pytest.skip`` guard.
 
 This file lives in ``src/skala/`` rather than ``src/skala/gpu4pyscf/`` so
 pytest can load it without first importing ``skala.gpu4pyscf``.
+Similar problems arise for torch_allocator and cupy.
 """
 
 import torch

--- a/src/skala/conftest.py
+++ b/src/skala/conftest.py
@@ -21,3 +21,4 @@ collect_ignore_glob: list[str] = []
 
 if not torch.cuda.is_available():
     collect_ignore_glob.append("gpu4pyscf/*.py")
+    collect_ignore_glob.append("utils/torch_allocator.py")

--- a/src/skala/gpu4pyscf/__init__.py
+++ b/src/skala/gpu4pyscf/__init__.py
@@ -35,11 +35,6 @@ from pyscf import gto
 
 from skala.functional import ExcFunctionalBase, load_functional
 from skala.gpu4pyscf import dft
-from skala.gpu4pyscf.torch_allocator import use_torch_mempool_in_cupy
-
-# Install this last because GPU4PySCF configures its own CuPy allocator during import.
-# Subsequent CuPy allocations use PyTorch's caching allocator
-use_torch_mempool_in_cupy()
 
 
 def SkalaKS(

--- a/src/skala/pyscf/backend.py
+++ b/src/skala/pyscf/backend.py
@@ -14,14 +14,14 @@ from torch import Tensor
 GPU_EXCEPTION: BaseException | None = None
 
 __all__ = [
+    "KS",
     "Array",
     "Grid",
-    "KS",
-    "dft_gpu",
     "check_gpu_imports_were_successful",
+    "dft_gpu",
     "from_numpy_or_cupy",
-    "to_numpy",
     "to_cupy",
+    "to_numpy",
 ]
 
 
@@ -39,6 +39,12 @@ else:
     try:
         import cupy
         from gpu4pyscf import dft as dft_gpu
+
+        from skala.utils.torch_allocator import use_torch_mempool_in_cupy
+
+        # Install this last because GPU4PySCF configures its own CuPy allocator during import.
+        # Subsequent CuPy allocations use PyTorch's caching allocator
+        use_torch_mempool_in_cupy()
 
         Array = TypeVar("Array", np.ndarray, cupy.ndarray)
         Grid: TypeAlias = dft.Grids | dft_gpu.Grids

--- a/src/skala/pyscf/backend.py
+++ b/src/skala/pyscf/backend.py
@@ -44,7 +44,16 @@ else:
 
         # Install this last because GPU4PySCF configures its own CuPy allocator during import.
         # Subsequent CuPy allocations use PyTorch's caching allocator
-        use_torch_mempool_in_cupy()
+        if not torch.cuda.is_available():
+            raise ImportError(
+                "CUDA is not available; cannot configure CuPy to use the PyTorch allocator."
+            )
+        try:
+            use_torch_mempool_in_cupy()
+        except RuntimeError as e:
+            raise ImportError(
+                "Failed to configure CuPy to use the PyTorch allocator."
+            ) from e
 
         Array = TypeVar("Array", np.ndarray, cupy.ndarray)
         Grid: TypeAlias = dft.Grids | dft_gpu.Grids

--- a/src/skala/utils/torch_allocator.py
+++ b/src/skala/utils/torch_allocator.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-"""Use torch allocator in CuPy.
+"""Use the PyTorch allocator in CuPy.
 
 Adapted from pytorch_pfn_extras.
 https://github.com/pfnet/pytorch-pfn-extras/blob/master/pytorch_pfn_extras/cuda/_allocator.py

--- a/src/skala/utils/torch_allocator.py
+++ b/src/skala/utils/torch_allocator.py
@@ -7,11 +7,9 @@ https://github.com/pfnet/pytorch-pfn-extras/blob/master/pytorch_pfn_extras/cuda/
 
 from typing import Any
 
+import cupy
 import torch
 
-if torch.cuda.is_available():
-    # Test collection can fail otherwise
-    import cupy
 _allocator = None
 
 

--- a/src/skala/utils/torch_allocator.py
+++ b/src/skala/utils/torch_allocator.py
@@ -7,9 +7,11 @@ https://github.com/pfnet/pytorch-pfn-extras/blob/master/pytorch_pfn_extras/cuda/
 
 from typing import Any
 
-import cupy
 import torch
 
+if torch.cuda.is_available():
+    # Test collection can fail otherwise
+    import cupy
 _allocator = None
 
 

--- a/tests/test_gpu4pyscf_gradients.py
+++ b/tests/test_gpu4pyscf_gradients.py
@@ -22,7 +22,7 @@ from pyscf import gto
 from test_pyscf_gradients import FULL_GRAD_REF
 
 from skala.functional.base import ExcFunctionalBase
-from skala.gpu4pyscf import SkalaKS, torch_allocator
+from skala.gpu4pyscf import SkalaKS
 from skala.gpu4pyscf.gradients import (
     SkalaRKSGradient,
     SkalaUKSGradient,
@@ -30,6 +30,7 @@ from skala.gpu4pyscf.gradients import (
     veff_and_expl_nuc_grad,
 )
 from skala.pyscf.features import generate_features
+from skala.utils import torch_allocator
 
 
 def test_torch_allocator_is_active_after_import() -> None:


### PR DESCRIPTION
There was a theoretical way the gpu4pyscf allocator could escape by someone directly importing backend. 

This does not work now, as backend sets the torch allocator and as a skala package it is imported after the gpu4pyscf everywhere, so only the torch allocator will be used. Tiny fix on #98 