### PR TITLE
Reduce CUDA memory use in non-local SKALA layers

### DIFF
--- a/src/skala/functional/model.py
+++ b/src/skala/functional/model.py
@@ -501,7 +501,21 @@ class NonLocalModel(nn.Module):
         h_fine = self.post_up_layer(h_fine)
 
         # Non-linear transform with skip connection
-        features = torch.cat([features, h_fine * exp_m1_rho_total], dim=-1)
+        update = h_fine * exp_m1_rho_total
+        if features.is_cuda:
+            concat_linear = cast(nn.Linear, self.concat_layer[0])
+            features = torch.nn.functional.linear(
+                features,
+                concat_linear.weight[:, : self.input_nf],
+                concat_linear.bias,
+            )
+            features = features + torch.nn.functional.linear(
+                update,
+                concat_linear.weight[:, self.input_nf :],
+            )
+            return self.concat_layer[1](features)
+
+        features = torch.cat([features, update], dim=-1)
         return self.concat_layer(features)
 
     @property

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -318,6 +318,60 @@ def test_nonlocal_model_snapshot() -> None:
     )
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_nonlocal_model_cuda_split_linear_matches_concat() -> None:
+    torch.manual_seed(42)
+    sph_irreps = Irreps.spherical_harmonics(1, p=1)
+    nlm = NonLocalModel(
+        input_nf=256,
+        hidden_nf=3,
+        lmax=1,
+        edge_irreps=sph_irreps,
+        coarse_linear_type="decomp-identity",
+        correlation=1,
+    ).cuda()
+
+    num_fine, num_coarse = 10, 4
+    h = torch.randn(num_fine, num_coarse, 256, device="cuda", requires_grad=True)
+    distance_ft = (
+        torch.randn(num_fine, num_coarse, 3, device="cuda").abs().requires_grad_()
+    )
+    direction_ft = torch.randn(
+        num_fine, num_coarse, 4, device="cuda", requires_grad=True
+    )
+    grid_weights = (
+        torch.randn(num_fine, num_coarse, dtype=torch.float64, device="cuda")
+        .abs()
+        .requires_grad_()
+    )
+    exp_m1_rho = (
+        torch.randn(num_fine, num_coarse, 1, device="cuda").abs().requires_grad_()
+    )
+
+    inputs = (h, distance_ft, direction_ft, grid_weights, exp_m1_rho)
+    concat_linear = nlm.concat_layer[0]
+    assert isinstance(concat_linear, torch.nn.Linear)
+    assert concat_linear.bias is not None
+    differentiated = (*inputs, concat_linear.weight, concat_linear.bias)
+    actual = nlm(*inputs)
+    actual_grads = torch.autograd.grad(actual.sum(), differentiated)
+
+    h_prepared = nlm.pre_down_layer(h)
+    down = nlm.tp_down(h_prepared, direction_ft, distance_weights=distance_ft)
+    h_coarse = torch.einsum("gck,gc->ck", down.double(), grid_weights.double()).to(
+        nlm.dtype
+    )
+    h_coarse = nlm.coarse_linear(h_coarse)
+    h_fine = nlm.tp_up(h_coarse, direction_ft, distance_weights=distance_ft)
+    h_fine = nlm.post_up_layer(h_fine)
+    expected = nlm.concat_layer(torch.cat([h, h_fine * exp_m1_rho], dim=-1))
+    expected_grads = torch.autograd.grad(expected.sum(), differentiated)
+
+    torch.testing.assert_close(actual, expected, rtol=2e-5, atol=2e-5)
+    for actual_grad, expected_grad in zip(actual_grads, expected_grads, strict=True):
+        torch.testing.assert_close(actual_grad, expected_grad, rtol=2e-5, atol=2e-5)
+
+
 def test_get_exc_density_snapshot_4atoms() -> None:
     torch.manual_seed(42)
     model = small_model()


### PR DESCRIPTION
## Summary

- avoid materializing the large fine-grid skip-connection concatenation on CUDA by applying the existing linear projection in two parts
- preserve the model parameters, state-dict layout, numerical precision, and CPU execution path
- retain the explicit double-precision grid reductions and geometry calculations

## Motivation

CUDA profiles of native-grid SKALA in CP2K show that the skip-connection concatenation creates a large short-lived fine-grid allocation and an associated copy kernel.

The split projection is mathematically equivalent to the existing concatenated linear layer:

`W [features, update] + b = W_features features + b + W_update update`

It reuses the existing weights and does not change checkpoint compatibility. This is primarily a memory optimization; the runtime effect is workload dependent.

## Validation

- `pytest -q tests/test_model.py`: 14 passed on an NVIDIA GB10
- `ruff check src/skala/functional/model.py tests/test_model.py`
- `ruff format --check src/skala/functional/model.py tests/test_model.py`
- CUDA tests compare the forward result, all five relevant input gradients, and the projection weight and bias gradients with the original concatenation path

A six-step, 96-atom CP2K SCF trajectory on the GB10 differed from the unchanged reference by at most `5.13e-8 Ha` in energy and `1e-8` in the convergence measure.

For the isolated split-projection comparison on two NVIDIA A40 GPUs, using three-run medians with identical weights and the unchanged double-precision reduction path:

- peak GPU memory decreased from `10253/8945 MiB` to `9093/7883 MiB`, or about `11-12%` per GPU
- CP2K time changed from `26.943 s` to `25.792 s` and wall time from `30.174 s` to `29.001 s`
- the maximum energy spread across all six runs was `3.34e-8 Ha`

An earlier isolated comparison showed only a `0.7%` runtime difference, so no general speedup is claimed.

## Model artifact

The source change takes effect after scripting/tracing a new CUDA `.fun` artifact. Existing published artifacts are not modified by this PR. A new CUDA model revision can be uploaded and added to the version mapping after this code is accepted; the CPU artifact can remain unchanged.

Related to cp2k/cp2k#5439.
