### PR TITLE
Add typed feature evaluation foundations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,12 +30,7 @@ jobs:
 
     - name: Run pre-commit hooks
       run: |
-        pre-commit install
         pre-commit run --all-files
-      shell: micromamba-shell {0}
-
-    - name: Run mypy
-      run: mypy .
       shell: micromamba-shell {0}
 
   test:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,18 @@ repos:
       # Run the formatter.
       - id: ruff-format
         args: [--config, pyproject.toml]
+
+  - repo: https://github.com/srstevenson/nb-clean
+    rev: f745b986570ef12cfbe0cfe20a7e0271c328914f  # frozen: 4.0.1
+    hooks:
+      - id: nb-clean
+
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy
+        entry: mypy
+        language: system
+        args: [--config-file, pyproject.toml, --num-workers, "4", .]
+        pass_filenames: false
+        always_run: true

--- a/docs/ase.ipynb
+++ b/docs/ase.ipynb
@@ -339,8 +339,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.13.5"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/pyscf/scf_settings.ipynb
+++ b/docs/pyscf/scf_settings.ipynb
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "ed3a3d47",
    "metadata": {},
    "outputs": [],
@@ -52,25 +52,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "a07500d7",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "converged SCF energy = -1.07091605172654\n",
-      "**** SCF Summaries ****\n",
-      "Total Energy =                          -1.070916051726540\n",
-      "Nuclear Repulsion Energy =               0.377654773327513\n",
-      "One-electron Energy =                   -1.897310624972360\n",
-      "Two-electron Coulomb Energy =            0.997543909702505\n",
-      "DFT Exchange-Correlation Energy =       -0.548804109784197\n",
-      "Empirical Dispersion Energy =           -0.000328948758201\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ks = SkalaKS(mol, xc=\"skala-1.1\")\n",
     "ks.kernel()\n",
@@ -88,19 +73,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "bce2aea4",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1e-09\n",
-      "None\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(ks.conv_tol)\n",
     "print(ks.conv_tol_grad)"
@@ -116,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "471f29ee",
    "metadata": {},
    "outputs": [],
@@ -142,19 +118,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "482ff510",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "5e-06\n",
-      "0.001\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(ks.conv_tol)\n",
     "print(ks.conv_tol_grad)"
@@ -184,8 +151,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/pyscf/singlepoint.ipynb
+++ b/docs/pyscf/singlepoint.ipynb
@@ -129,8 +129,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.14.2"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -8,6 +8,7 @@ dependencies:
   - dftd3-python
   - e3nn
   - h5py
+  - hdf5 >=2.1,<2.2
   - numpy <2.5
   - opt_einsum_fx
   - pyscf >=2.8,<2.14
@@ -20,6 +21,6 @@ dependencies:
   - pytest-cov
   - pytest-randomly
   - ruff
-  - mypy
+  - mypy >=2
   - pip:
     - huggingface_hub

--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -8,6 +8,7 @@ dependencies:
   - dftd3-python
   - e3nn
   - h5py
+  - hdf5 >=2.1,<2.2
   - numpy
   - opt_einsum_fx
   - pyscf >=2.8,<2.14
@@ -23,7 +24,7 @@ dependencies:
   - pytest-cov
   - pytest-randomly
   - ruff
-  - mypy
+  - mypy >=2
   - pip:
     - huggingface_hub
     - gpu4pyscf-cuda12x >=1.6,<1.8,!=1.7.1,!=1.7.2

--- a/examples/cpp/cpp_integration/prepare_inputs.py
+++ b/examples/cpp/cpp_integration/prepare_inputs.py
@@ -7,12 +7,9 @@ import torch
 from pyscf import dft, gto
 from pyscf.dft import gen_grid
 
+from skala.functional.model import SkalaFunctional
 from skala.functional.traditional import LDA
-from skala.pyscf.features import (
-    _ATOMIC_GRID_FEATURES,
-    DEFAULT_FEATURES_SET,
-    generate_features,
-)
+from skala.pyscf.features import generate_features
 
 
 def main() -> None:
@@ -45,11 +42,8 @@ def main() -> None:
     grid.level = 3
     grid.build(sort_grids=False)
     features = generate_features(
-        molecule, dm, grid, features=DEFAULT_FEATURES_SET | _ATOMIC_GRID_FEATURES
+        molecule, dm, grid, features=set(SkalaFunctional.features)
     )
-
-    # Add a feature called `coarse_0_atomic_coords` containing the atomic coordinates.
-    features["coarse_0_atomic_coords"] = torch.from_numpy(molecule.atom_coords())
 
     # Save all features as individual .pt files.
     for key, value in features.items():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 
 optional-dependencies.dev = [
     "pre-commit",
-    "mypy",
+    "mypy>=2",
     "pytest",
     "pytest-cov",
     "pytest-randomly",
@@ -116,6 +116,8 @@ filterwarnings = [
     'ignore:using cupy as the tensor contraction engine\.:UserWarning',
     # Deprecation warning in huggingface_hub package
     'ignore:hf_xet\.download_files\(\) is deprecated\. Use XetSession\(\)\.new_file_download_group\(\)\.start_download_file\(\) instead\.:DeprecationWarning',
+    # ASE directly assigns array shapes in `Atoms.new_array`, deprecated by NumPy 2.5.
+    'ignore:Setting the shape on a NumPy array has been deprecated in NumPy 2\.5\.:DeprecationWarning',
     # Upstream deprecations in PySCF / GPU4PySCF are outside this project's control.
     'ignore::DeprecationWarning:pyscf\..*',
     'ignore::DeprecationWarning:gpu4pyscf\..*',

--- a/src/skala/ase/__init__.py
+++ b/src/skala/ase/__init__.py
@@ -8,6 +8,6 @@ except ModuleNotFoundError as e:
     ) from e
 
 
-from skala.ase.calculator import Skala  # noqa: F401
+from skala.ase.calculator import Skala
 
 __all__ = ["Skala"]

--- a/src/skala/features.py
+++ b/src/skala/features.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: MIT
+
+"""Names of built-in molecular features."""
+
+from enum import Enum
+from typing import TYPE_CHECKING, TypeAlias
+
+if TYPE_CHECKING:
+    from torch import Tensor
+
+
+class Feature(str, Enum):  # noqa: UP042 - Python 3.10-compatible StrEnum
+    """String-compatible names of features understood by Skala."""
+
+    DENSITY = "density"
+    GRAD = "grad"
+    KIN = "kin"
+    LAPL = "lapl"
+    GRID_COORDS = "grid_coords"
+    GRID_WEIGHTS = "grid_weights"
+    ATOMIC_GRID_WEIGHTS = "atomic_grid_weights"
+    ATOMIC_GRID_SIZES = "atomic_grid_sizes"
+    ATOMIC_GRID_SIZE_BOUND_SHAPE = "atomic_grid_size_bound_shape"
+    COARSE_0_ATOMIC_COORDS = "coarse_0_atomic_coords"
+
+    __str__ = str.__str__
+
+
+FeatureMap: TypeAlias = dict[Feature, "Tensor"]

--- a/src/skala/functional/__init__.py
+++ b/src/skala/functional/__init__.py
@@ -30,9 +30,6 @@ from skala.functional.traditional import (
 )
 
 __all__ = [
-    "ExcFunctionalBase",
-    "SkalaFunctional",
-    "TracedFunctional",
     "LDA",
     "PBE",
     "R2SCAN",
@@ -40,6 +37,9 @@ __all__ = [
     "SCAN",
     "SPW92",
     "TPSS",
+    "ExcFunctionalBase",
+    "SkalaFunctional",
+    "TracedFunctional",
     "load_functional",
 ]
 
@@ -80,12 +80,13 @@ def load_functional(
         name string for PySCF-native functionals.
 
     Example:
+        >>> from skala.features import Feature
         >>> func = load_functional("skala-1.1")
-        >>> func.features
-        ['density', 'kin', 'grad', 'grid_coords', 'grid_weights', ...
+        >>> func.features[:3] == [Feature.DENSITY, Feature.KIN, Feature.GRAD]
+        True
         >>> func = load_functional("lda")
-        >>> func.features
-        ['density', 'grid_weights']
+        >>> func.features == [Feature.DENSITY, Feature.GRID_WEIGHTS]
+        True
         >>> load_functional("b3lyp")
         'b3lyp'
     """

--- a/src/skala/functional/base.py
+++ b/src/skala/functional/base.py
@@ -13,6 +13,8 @@ from typing import Any
 import torch
 from torch import nn
 
+from skala.features import Feature, FeatureMap
+
 VxcType = tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
 
 
@@ -25,7 +27,7 @@ class ExcFunctionalBase(nn.Module):
     energy density from molecular features.
     """
 
-    features: list[str]
+    features: list[Feature]
     """List of features that this functional requires."""
 
     def get_d3_settings(self) -> str | None:
@@ -35,7 +37,7 @@ class ExcFunctionalBase(nn.Module):
         """
         return None
 
-    def get_exc_density(self, mol: dict[str, torch.Tensor]) -> torch.Tensor:
+    def get_exc_density(self, mol: FeatureMap) -> torch.Tensor:
         """
         Returns the exchange-correlation density for the given molecule.
         It should return a tensor of shape (G,) where G is the number of grid points
@@ -46,7 +48,7 @@ class ExcFunctionalBase(nn.Module):
             "get_exc_density not implemented for this functional."
         )
 
-    def get_exc(self, mol: dict[str, torch.Tensor]) -> torch.Tensor:
+    def get_exc(self, mol: FeatureMap) -> torch.Tensor:
         """
         Compute the exchange-correlation energy.
 
@@ -62,7 +64,7 @@ class ExcFunctionalBase(nn.Module):
             The total exchange-correlation energy.
         """
         exc_density = self.get_exc_density(mol).double()
-        grid_weights = mol["grid_weights"].double()
+        grid_weights = mol[Feature.GRID_WEIGHTS].double()
 
         return (exc_density * grid_weights).sum()
 

--- a/src/skala/functional/density.py
+++ b/src/skala/functional/density.py
@@ -14,13 +14,13 @@ from collections.abc import Callable
 import torch
 from torch import Tensor
 
+from skala.features import Feature, FeatureMap
+
 EPS = 1e-10
-IMMUTABLES = frozenset(["grid_coords", "grid_weights"])
+IMMUTABLES: frozenset[Feature] = frozenset([Feature.GRID_COORDS, Feature.GRID_WEIGHTS])
 
 
-def _map(
-    mol_features: dict[str, Tensor], f: Callable[[Tensor], Tensor]
-) -> dict[str, Tensor]:
+def _map(mol_features: FeatureMap, f: Callable[[Tensor], Tensor]) -> FeatureMap:
     """
     Apply a function to mutable molecular features.
 
@@ -43,8 +43,8 @@ def _map(
 
 
 def separate(
-    mol_features: dict[str, Tensor],
-) -> tuple[dict[str, Tensor], dict[str, Tensor]]:
+    mol_features: FeatureMap,
+) -> tuple[FeatureMap, FeatureMap]:
     """
     Separate molecular features into spin-up and spin-down components.
 
@@ -74,7 +74,7 @@ def separate(
     return mol_a, mol_b
 
 
-def scale_by(mol_features: dict[str, Tensor], factor: float) -> dict[str, Tensor]:
+def scale_by(mol_features: FeatureMap, factor: float) -> FeatureMap:
     """
     Scale molecular features by a constant factor.
 

--- a/src/skala/functional/load.py
+++ b/src/skala/functional/load.py
@@ -13,6 +13,7 @@ from typing import IO, Any, cast
 
 import torch
 
+from skala.features import Feature, FeatureMap
 from skala.functional.base import ExcFunctionalBase
 
 PROTOCOL_VERSION = 2
@@ -46,7 +47,7 @@ class TracedFunctional(ExcFunctionalBase):
         super().__init__()
         self._traced_model = traced_model
         self.metadata = dict(metadata)
-        self.features = list(features)
+        self.features = [Feature(feature) for feature in features]
         self.expected_d3_settings = expected_d3_settings
 
     def get_d3_settings(self) -> str | None:
@@ -56,10 +57,10 @@ class TracedFunctional(ExcFunctionalBase):
         """
         return self.expected_d3_settings
 
-    def get_exc_density(self, mol: dict[str, torch.Tensor]) -> torch.Tensor:
+    def get_exc_density(self, mol: FeatureMap) -> torch.Tensor:
         return self._traced_model.get_exc_density(mol)
 
-    def get_exc(self, mol: dict[str, torch.Tensor]) -> torch.Tensor:
+    def get_exc(self, mol: FeatureMap) -> torch.Tensor:
         return self._traced_model.get_exc(mol)
 
     @property
@@ -125,7 +126,7 @@ class TracedFunctional(ExcFunctionalBase):
             raise RuntimeError(
                 "metadata in traced functional extra_files does not have the correct format (dict)."
             )
-        if not all([isinstance(key, str) for key in _metadata]):
+        if not all(isinstance(key, str) for key in _metadata):
             raise RuntimeError("metadata keys in traced functional must be strings.")
         metadata = cast(dict[str, Any], _metadata)
 
@@ -134,7 +135,7 @@ class TracedFunctional(ExcFunctionalBase):
             raise RuntimeError(
                 "features in traced functional extra_files does not have the correct format (list)."
             )
-        if not all([isinstance(feat, str) for feat in _features]):
+        if not all(isinstance(feat, str) for feat in _features):
             raise RuntimeError(
                 "features in traced functional must be a list of strings."
             )

--- a/src/skala/functional/model.py
+++ b/src/skala/functional/model.py
@@ -9,13 +9,14 @@ layers and symmetric contraction for higher-order body correlations.
 """
 
 import math
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 import torch
 from e3nn import o3
 from opt_einsum_fx import jitable, optimize_einsums_full
 from torch import fx, nn
 
+from skala.features import Feature, FeatureMap
 from skala.functional.base import ExcFunctionalBase, enhancement_density_inner_product
 from skala.functional.layers import ScaledSigmoid
 from skala.functional.utils.irreps import Irreps
@@ -25,9 +26,7 @@ from skala.functional.utils.symmetric_contraction import SymmetricContraction
 ANGSTROM_TO_BOHR = 1.88973
 
 
-def _prepare_features_raw(
-    mol: dict[str, torch.Tensor], eps: float = 1e-5
-) -> torch.Tensor:
+def _prepare_features_raw(mol: FeatureMap, eps: float = 1e-5) -> torch.Tensor:
     """Compute log-space semi-local features from packed density data.
 
     Args:
@@ -39,10 +38,10 @@ def _prepare_features_raw(
     """
     x = torch.cat(
         [
-            mol["density"].permute(1, 2, 0),
-            (mol["grad"] ** 2).sum(1).permute(1, 2, 0),
-            mol["kin"].permute(1, 2, 0),
-            (mol["grad"].sum(0) ** 2).sum(0).unsqueeze(-1),
+            mol[Feature.DENSITY].permute(1, 2, 0),
+            (mol[Feature.GRAD] ** 2).sum(1).permute(1, 2, 0),
+            mol[Feature.KIN].permute(1, 2, 0),
+            (mol[Feature.GRAD].sum(0) ** 2).sum(0).unsqueeze(-1),
         ],
         dim=-1,
     )
@@ -57,7 +56,7 @@ def _prepare_features_raw(
 class SemiLocalFeatures(nn.Module):
     """Compute semi-local (ab, ba) feature pairs with a pre-buffered permutation index."""
 
-    _PERM = [1, 0, 3, 2, 5, 4, 6]
+    _PERM: ClassVar[list[int]] = [1, 0, 3, 2, 5, 4, 6]
     _feature_perm: torch.Tensor
 
     def __init__(self) -> None:
@@ -68,9 +67,7 @@ class SemiLocalFeatures(nn.Module):
             persistent=False,
         )
 
-    def forward(
-        self, mol: dict[str, torch.Tensor]
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    def forward(self, mol: FeatureMap) -> tuple[torch.Tensor, torch.Tensor]:
         features = _prepare_features_raw(mol)
         features_ab = features
         features_ba = features.index_select(-1, self._feature_perm)
@@ -127,15 +124,15 @@ class SkalaFunctional(ExcFunctionalBase):
     """
 
     features = [
-        "density",
-        "kin",
-        "grad",
-        "grid_coords",
-        "grid_weights",
-        "atomic_grid_weights",
-        "atomic_grid_sizes",
-        "coarse_0_atomic_coords",
-        "atomic_grid_size_bound_shape",
+        Feature.DENSITY,
+        Feature.KIN,
+        Feature.GRAD,
+        Feature.GRID_COORDS,
+        Feature.GRID_WEIGHTS,
+        Feature.ATOMIC_GRID_WEIGHTS,
+        Feature.ATOMIC_GRID_SIZES,
+        Feature.COARSE_0_ATOMIC_COORDS,
+        Feature.ATOMIC_GRID_SIZE_BOUND_SHAPE,
     ]
 
     def __init__(
@@ -250,9 +247,7 @@ class SkalaFunctional(ExcFunctionalBase):
     def dtype(self) -> torch.dtype:
         return cast(nn.Linear, self.input_model[0]).weight.dtype
 
-    def pack_features(
-        self, mol_feats: dict[str, torch.Tensor]
-    ) -> dict[str, torch.Tensor]:
+    def pack_features(self, mol_feats: FeatureMap) -> FeatureMap:
         """Pack flat features into dense (grid_per_atom, atoms, …) layout.
 
         Args:
@@ -261,49 +256,52 @@ class SkalaFunctional(ExcFunctionalBase):
         Returns:
             Packed features dictionary.
         """
-        atomic_grid_sizes = mol_feats["atomic_grid_sizes"]
-        size_bound = mol_feats["atomic_grid_size_bound_shape"].shape[0]
+        atomic_grid_sizes = mol_feats[Feature.ATOMIC_GRID_SIZES]
+        size_bound = mol_feats[Feature.ATOMIC_GRID_SIZE_BOUND_SHAPE].shape[0]
 
-        packed_mol_feats: dict[str, torch.Tensor] = {}
+        packed_mol_feats: FeatureMap = {}
         for key in self.features:
-            if key == "atomic_grid_weights":
+            if key == Feature.ATOMIC_GRID_WEIGHTS:
                 packed_mol_feats[key] = pad_ragged(
                     mol_feats[key], atomic_grid_sizes, size_bound
                 ).T  # (max_grid_size, num_atoms)
-            elif key == "grid_weights":
+            elif key == Feature.GRID_WEIGHTS:
                 continue
-            elif key == "grid_coords":
+            elif key == Feature.GRID_COORDS:
                 packed_mol_feats[key] = pad_ragged(
                     mol_feats[key], atomic_grid_sizes, size_bound
                 ).permute(1, 0, 2)  # (max_grid_size, num_atoms, 3)
-            elif key == "coarse_0_atomic_coords":
+            elif key == Feature.COARSE_0_ATOMIC_COORDS:
                 packed_mol_feats[key] = mol_feats[key]
-            elif key == "density":
+            elif key == Feature.DENSITY:
                 packed_mol_feats[key] = pad_ragged(
                     mol_feats[key].T, atomic_grid_sizes, size_bound
                 ).permute(2, 1, 0)  # (2, max_grid_size, num_atoms)
-            elif key == "grad":
+            elif key == Feature.GRAD:
                 packed_mol_feats[key] = pad_ragged(
                     mol_feats[key].permute(2, 0, 1), atomic_grid_sizes, size_bound
                 ).permute(2, 3, 1, 0)  # (2, 3, max_grid_size, num_atoms)
-            elif key == "kin":
+            elif key == Feature.KIN:
                 packed_mol_feats[key] = pad_ragged(
                     mol_feats[key].T, atomic_grid_sizes, size_bound
                 ).permute(2, 1, 0)  # (2, max_grid_size, num_atoms)
-            elif key in ("atomic_grid_sizes", "atomic_grid_size_bound_shape"):
+            elif key in (
+                Feature.ATOMIC_GRID_SIZES,
+                Feature.ATOMIC_GRID_SIZE_BOUND_SHAPE,
+            ):
                 continue
             else:
                 raise ValueError(f"Unexpected key: {key}")
 
         return packed_mol_feats
 
-    def get_exc(self, mol: dict[str, torch.Tensor]) -> torch.Tensor:
+    def get_exc(self, mol: FeatureMap) -> torch.Tensor:
         exc_density = self._get_exc_density_padded(mol).double()
         grid_weights = (
             pad_ragged(
-                mol["grid_weights"],
-                mol["atomic_grid_sizes"],
-                mol["atomic_grid_size_bound_shape"].shape[0],
+                mol[Feature.GRID_WEIGHTS],
+                mol[Feature.ATOMIC_GRID_SIZES],
+                mol[Feature.ATOMIC_GRID_SIZE_BOUND_SHAPE].shape[0],
             )
             .T.double()
             .reshape(-1)
@@ -311,20 +309,20 @@ class SkalaFunctional(ExcFunctionalBase):
 
         return (exc_density * grid_weights).sum()
 
-    def get_exc_density(self, mol: dict[str, torch.Tensor]) -> torch.Tensor:
+    def get_exc_density(self, mol: FeatureMap) -> torch.Tensor:
         padded = self._get_exc_density_padded(mol)
-        sizes = mol["atomic_grid_sizes"]
-        size_bound = mol["atomic_grid_size_bound_shape"].shape[0]
+        sizes = mol[Feature.ATOMIC_GRID_SIZES]
+        size_bound = mol[Feature.ATOMIC_GRID_SIZE_BOUND_SHAPE].shape[0]
         num_atoms = sizes.shape[0]
-        total_grid_points = mol["grid_weights"].shape[0]
+        total_grid_points = mol[Feature.GRID_WEIGHTS].shape[0]
         padded_2d = padded.reshape(size_bound, num_atoms).T
         return unpad_ragged(padded_2d, sizes, total_grid_points)
 
-    def _get_exc_density_padded(self, mol: dict[str, torch.Tensor]) -> torch.Tensor:
+    def _get_exc_density_padded(self, mol: FeatureMap) -> torch.Tensor:
         mol = self.pack_features(mol)
-        grid_coords = mol["grid_coords"]
-        atomic_grid_weights = mol["atomic_grid_weights"]
-        coarse_coords = mol["coarse_0_atomic_coords"]
+        grid_coords = mol[Feature.GRID_COORDS]
+        atomic_grid_weights = mol[Feature.ATOMIC_GRID_WEIGHTS]
+        coarse_coords = mol[Feature.COARSE_0_ATOMIC_COORDS]
         features_ab, features_ba = self.semi_local_features(mol)
 
         # Learned symmetrized features
@@ -352,7 +350,7 @@ class SkalaFunctional(ExcFunctionalBase):
                 directions
             )  # (num_fine, num_coarse, (lmax+1)^2)
 
-            exp_m1_rho_total = torch.exp(-mol["density"].sum(0).unsqueeze(-1)).to(
+            exp_m1_rho_total = torch.exp(-mol[Feature.DENSITY].sum(0).unsqueeze(-1)).to(
                 self.dtype
             )
 
@@ -368,7 +366,7 @@ class SkalaFunctional(ExcFunctionalBase):
         enhancement_factor = self.output_model(features)
         return enhancement_density_inner_product(
             enhancement_factor=enhancement_factor.view(-1, 1),
-            density=mol["density"].reshape(2, -1),
+            density=mol[Feature.DENSITY].reshape(2, -1),
         )
 
     def reset_parameters(self) -> None:
@@ -912,7 +910,7 @@ def _o3_linear_codegen(
         for i_in, i_out in instr
     ]
 
-    outs: list[Any] = list()
+    outs: list[Any] = []
     for (i_in, i_out), w in zip(instr, weights, strict=True):
         x1_i = x1[:, slices[0][i_in][0] : slices[0][i_in][1]]  # type: ignore
         outs.append(

--- a/src/skala/functional/traditional.py
+++ b/src/skala/functional/traditional.py
@@ -12,6 +12,7 @@ import math
 import torch
 from torch import Tensor, nn
 
+from skala.features import Feature, FeatureMap
 from skala.functional import density
 from skala.functional.base import ExcFunctionalBase
 
@@ -27,7 +28,7 @@ class SpinScaledXCFunctional(ExcFunctionalBase):
     def get_d3_settings(self) -> str:
         return self.__class__.__name__.lower()
 
-    def exchange(self, mol_features: dict[str, Tensor]) -> Tensor:
+    def exchange(self, mol_features: FeatureMap) -> Tensor:
         """
         Compute the exchange energy density.
 
@@ -43,7 +44,7 @@ class SpinScaledXCFunctional(ExcFunctionalBase):
         """
         raise NotImplementedError()
 
-    def correlation_density(self, mol_features: dict[str, Tensor]) -> Tensor:
+    def correlation_density(self, mol_features: FeatureMap) -> Tensor:
         """
         Compute the correlation energy density.
 
@@ -59,7 +60,7 @@ class SpinScaledXCFunctional(ExcFunctionalBase):
         """
         raise NotImplementedError()
 
-    def correlation(self, mol_features: dict[str, Tensor]) -> Tensor:
+    def correlation(self, mol_features: FeatureMap) -> Tensor:
         """
         Compute the correlation energy.
 
@@ -73,10 +74,10 @@ class SpinScaledXCFunctional(ExcFunctionalBase):
         Tensor
             Correlation energy.
         """
-        rho_total = mol_features["density"].sum(0)
+        rho_total = mol_features[Feature.DENSITY].sum(0)
         return rho_total * self.correlation_density(mol_features)
 
-    def get_exc_density(self, mol: dict[str, Tensor]) -> Tensor:
+    def get_exc_density(self, mol: FeatureMap) -> Tensor:
         exch = self.exchange(density.scale_by(mol, 2)).sum(0) / 2
         corr = self.correlation(mol)
         return exch + corr
@@ -90,15 +91,21 @@ class LDA(SpinScaledXCFunctional):
     Exchange: E_x[ρ] = -3/4 * (3/π)^(1/3) * ρ^(4/3)
     """
 
-    features = ["density", "grid_weights"]
+    features = [
+        Feature.DENSITY,
+        Feature.GRID_WEIGHTS,
+    ]
 
-    def exchange(self, mol_features: dict[str, Tensor]) -> Tensor:
+    def exchange(self, mol_features: FeatureMap) -> Tensor:
         return (
-            -3 / 4 * (3 / math.pi) ** (1 / 3) * mol_features["density"].abs() ** (4 / 3)
+            -3
+            / 4
+            * (3 / math.pi) ** (1 / 3)
+            * mol_features[Feature.DENSITY].abs() ** (4 / 3)
         )
 
-    def correlation_density(self, mol_features: dict[str, Tensor]) -> Tensor:
-        return mol_features["density"].new_zeros((1,))
+    def correlation_density(self, mol_features: FeatureMap) -> Tensor:
+        return mol_features[Feature.DENSITY].new_zeros((1,))
 
 
 class SPW92(SpinScaledXCFunctional):
@@ -109,14 +116,20 @@ class SPW92(SpinScaledXCFunctional):
     correlation energy of the uniform electron gas.
     """
 
-    features = ["density", "grid_weights"]
+    features = [
+        Feature.DENSITY,
+        Feature.GRID_WEIGHTS,
+    ]
 
-    def exchange(self, mol_features: dict[str, Tensor]) -> Tensor:
+    def exchange(self, mol_features: FeatureMap) -> Tensor:
         return (
-            -3 / 4 * (3 / math.pi) ** (1 / 3) * mol_features["density"].abs() ** (4 / 3)
+            -3
+            / 4
+            * (3 / math.pi) ** (1 / 3)
+            * mol_features[Feature.DENSITY].abs() ** (4 / 3)
         )
 
-    def correlation_density(self, mol_features: dict[str, Tensor]) -> Tensor:
+    def correlation_density(self, mol_features: FeatureMap) -> Tensor:
         def Gamma(
             rs: Tensor, A: float, a1: float, b1: float, b2: float, b3: float, b4: float
         ) -> Tensor:
@@ -124,7 +137,7 @@ class SPW92(SpinScaledXCFunctional):
             poly = (b1 + (b2 + (b3 + b4 * rs_sq) * rs_sq) * rs_sq) * rs_sq
             return -2 * A * (1 + a1 * rs) * torch.log(1 + 0.5 / (A * poly))
 
-        rho = mol_features["density"]
+        rho = mol_features[Feature.DENSITY]
         zeta, rho_total = density.zeta(rho), rho.sum(0)
         ff0 = 1.709921
         ff = ((1 + zeta) ** (4 / 3) + (1 - zeta) ** (4 / 3) - 2) / (2 ** (4 / 3) - 2)
@@ -147,7 +160,11 @@ class PBE(SpinScaledXCFunctional):
     and correlation gradient corrections to the local density approximation.
     """
 
-    features = ["density", "grad", "grid_weights"]
+    features = [
+        Feature.DENSITY,
+        Feature.GRAD,
+        Feature.GRID_WEIGHTS,
+    ]
 
     def __init__(self) -> None:
         super().__init__()
@@ -156,9 +173,9 @@ class PBE(SpinScaledXCFunctional):
         self.kappa = nn.Parameter(torch.tensor(0.804), requires_grad=False)
         self.mu = self.beta * (math.pi**2 / 3)
 
-    def exchange(self, mol_features: dict[str, Tensor]) -> Tensor:
-        rho = mol_features["density"]
-        grad = mol_features["grad"]
+    def exchange(self, mol_features: FeatureMap) -> Tensor:
+        rho = mol_features[Feature.DENSITY]
+        grad = mol_features[Feature.GRAD]
         FX = (
             1
             + self.kappa
@@ -167,10 +184,10 @@ class PBE(SpinScaledXCFunctional):
         )
         return self.lda.exchange(mol_features) * FX
 
-    def correlation_density(self, mol_features: dict[str, Tensor]) -> Tensor:
+    def correlation_density(self, mol_features: FeatureMap) -> Tensor:
         eps_c_unif = self.lda.correlation_density(mol_features)
-        rho = mol_features["density"]
-        grad = mol_features["grad"]
+        rho = mol_features[Feature.DENSITY]
+        grad = mol_features[Feature.GRAD]
         rho_total, grad_total = rho.sum(0), grad.sum(0)
         zeta = density.zeta(rho)
         ks = torch.sqrt(4 * density.kF(rho_total) / math.pi)
@@ -200,7 +217,12 @@ class TPSS(SpinScaledXCFunctional):
     exact constraints of density functional theory.
     """
 
-    features = ["density", "kin", "grad", "grid_weights"]
+    features = [
+        Feature.DENSITY,
+        Feature.KIN,
+        Feature.GRAD,
+        Feature.GRID_WEIGHTS,
+    ]
 
     def __init__(self) -> None:
         super().__init__()
@@ -211,10 +233,10 @@ class TPSS(SpinScaledXCFunctional):
         self.b = nn.Parameter(torch.tensor(0.40), requires_grad=False)
         self.d = nn.Parameter(torch.tensor(2.8), requires_grad=False)
 
-    def exchange(self, mol_features: dict[str, Tensor]) -> Tensor:
-        rho = mol_features["density"]
-        grad = mol_features["grad"]
-        kin = mol_features["kin"]
+    def exchange(self, mol_features: FeatureMap) -> Tensor:
+        rho = mol_features[Feature.DENSITY]
+        grad = mol_features[Feature.GRAD]
+        kin = mol_features[Feature.KIN]
         # p is the reduced gradient squared, z is the zeta value
         p, z = density.reduced_gradient(rho, grad) ** 2, density.z(rho, grad, kin)
         alpha = (5 * p / 3) * (1 / torch.clamp(z, density.EPS) - 1)
@@ -233,10 +255,10 @@ class TPSS(SpinScaledXCFunctional):
         FX = 1 + kappa - kappa / (1 + x / kappa)
         return self.lda.exchange(mol_features) * FX
 
-    def correlation_density(self, mol_features: dict[str, Tensor]) -> Tensor:
-        rho = mol_features["density"]
-        grad = mol_features["grad"]
-        kin = mol_features["kin"]
+    def correlation_density(self, mol_features: FeatureMap) -> Tensor:
+        rho = mol_features[Feature.DENSITY]
+        grad = mol_features[Feature.GRAD]
+        kin = mol_features[Feature.KIN]
         rho_total, grad_total, kin_total = rho.sum(0), grad.sum(0), kin.sum(0)
         zeta, grad_zeta = density.zeta(rho), density.grad_zeta(rho, grad).norm(dim=-2)
 
@@ -253,7 +275,7 @@ class TPSS(SpinScaledXCFunctional):
         z = density.z(rho_total, grad_total, kin_total)
         mols = density.separate(mol_features)
         eps_c_revpkzb = eps_c_pbe * (1 + Czetaxi * z**2) - (1 + Czetaxi) * z**2 * sum(
-            (mols[spin]["density"][spin] / rho_total)
+            (mols[spin][Feature.DENSITY][spin] / rho_total)
             * torch.max(eps_c_pbe, self.pbe.correlation_density(mols[spin]))
             for spin in range(2)
         )
@@ -261,7 +283,12 @@ class TPSS(SpinScaledXCFunctional):
 
 
 class _SCANLikeFunctional(SpinScaledXCFunctional):
-    features = ["density", "kin", "grad", "grid_weights"]
+    features = [
+        Feature.DENSITY,
+        Feature.KIN,
+        Feature.GRAD,
+        Feature.GRID_WEIGHTS,
+    ]
 
     def __init__(
         self, alpha_mode: int, interpolation_mode: int, gradient_correction_mode: int
@@ -677,16 +704,16 @@ class _SCANLikeFunctional(SpinScaledXCFunctional):
         energy = ec1 + ief * (ec0 - ec1)
         return torch.where(total_density > 0, energy, torch.zeros_like(energy))
 
-    def exchange(self, mol_features: dict[str, Tensor]) -> Tensor:
-        rho = torch.clamp(mol_features["density"], min=0.0)
-        grad_norm = density.grad_norm(mol_features["grad"])
-        kin = torch.clamp(mol_features["kin"], min=0.0)
+    def exchange(self, mol_features: FeatureMap) -> Tensor:
+        rho = torch.clamp(mol_features[Feature.DENSITY], min=0.0)
+        grad_norm = density.grad_norm(mol_features[Feature.GRAD])
+        kin = torch.clamp(mol_features[Feature.KIN], min=0.0)
         return self._scan_exchange_density(rho, grad_norm, kin)
 
-    def correlation_density(self, mol_features: dict[str, Tensor]) -> Tensor:
-        rho = torch.clamp(mol_features["density"], min=0.0)
-        grad = mol_features["grad"]
-        kin = torch.clamp(mol_features["kin"], min=0.0)
+    def correlation_density(self, mol_features: FeatureMap) -> Tensor:
+        rho = torch.clamp(mol_features[Feature.DENSITY], min=0.0)
+        grad = mol_features[Feature.GRAD]
+        kin = torch.clamp(mol_features[Feature.KIN], min=0.0)
         return self._scan_correlation_per_particle(rho, grad, kin)
 
 

--- a/src/skala/functional/utils/irreps.py
+++ b/src/skala/functional/utils/irreps.py
@@ -111,7 +111,7 @@ class Irrep:
 
 
 class MulIr:
-    __slots__ = ("_mul", "_ir")
+    __slots__ = ("_ir", "_mul")
     _mul: int
     _ir: Irrep
 

--- a/src/skala/gpu4pyscf/gradients.py
+++ b/src/skala/gpu4pyscf/gradients.py
@@ -18,6 +18,7 @@ from pyscf import gto
 from torch.utils.dlpack import from_dlpack
 
 import skala.pyscf.features as feature
+from skala.features import Feature, FeatureMap
 from skala.functional.base import ExcFunctionalBase
 
 LOG = logging.getLogger(__name__)
@@ -28,7 +29,7 @@ def veff_and_expl_nuc_grad(
     mol: gto.Mole,
     grid: dft.Grids,
     rdm1: torch.Tensor,
-    nuc_grad_feats: set[str] | None = None,
+    nuc_grad_feats: set[Feature] | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
     returns:
@@ -37,21 +38,21 @@ def veff_and_expl_nuc_grad(
     """
 
     SUPPORTED_FEATS = {
-        "density",
-        "grad",
-        "kin",
-        "grid_coords",
-        "grid_weights",
-        "atomic_grid_weights",
-        "coarse_0_atomic_coords",
+        Feature.DENSITY,
+        Feature.GRAD,
+        Feature.KIN,
+        Feature.GRID_COORDS,
+        Feature.GRID_WEIGHTS,
+        Feature.ATOMIC_GRID_WEIGHTS,
+        Feature.COARSE_0_ATOMIC_COORDS,
     }
 
     if nuc_grad_feats is None:  # generate feature list from functional features
         nuc_grad_feats = set(functional.features)
 
     # Integer-valued features have no nuclear gradient — always discard them
-    nuc_grad_feats.discard("atomic_grid_sizes")
-    nuc_grad_feats.discard("atomic_grid_size_bound_shape")
+    nuc_grad_feats.discard(Feature.ATOMIC_GRID_SIZES)
+    nuc_grad_feats.discard(Feature.ATOMIC_GRID_SIZE_BOUND_SHAPE)
 
     # check for unsupported features
     unsupported_feats = {feat for feat in nuc_grad_feats if feat not in SUPPORTED_FEATS}
@@ -63,9 +64,9 @@ def veff_and_expl_nuc_grad(
     LOG.debug("nuc_grad_feats = %s", nuc_grad_feats)
 
     # determine the maximum ao derivative needed
-    if "grad" in nuc_grad_feats or "kin" in nuc_grad_feats:
+    if Feature.GRAD in nuc_grad_feats or Feature.KIN in nuc_grad_feats:
         ao_deriv = 2
-    elif "density" in nuc_grad_feats:
+    elif Feature.DENSITY in nuc_grad_feats:
         ao_deriv = 1
     else:
         ao_deriv = 0
@@ -87,13 +88,13 @@ def veff_and_expl_nuc_grad(
     # Discard atomic_grid_weights from VJP features: d(atomic_grid_weights)/dR = 0
     # because they are raw quadrature weights that depend only on the radial/angular
     # grid rule, not on nuclear positions. They still pass through as other_feats.
-    nuc_grad_feats.discard("atomic_grid_weights")
+    nuc_grad_feats.discard(Feature.ATOMIC_GRID_WEIGHTS)
 
     # Get required derivatives
     nuc_feat_names = list(nuc_grad_feats)  # ensure specific order
     nuc_feat_tensors = [mol_feats[feat] for feat in nuc_feat_names]
     other_feats = {
-        feat: mol_feats[feat] for feat in mol_feats.keys() if feat not in nuc_grad_feats
+        feat: mol_feats[feat] for feat in mol_feats if feat not in nuc_grad_feats
     }
 
     def exc_feat_func(*nuc_feat_tensors: torch.Tensor) -> torch.Tensor:
@@ -118,7 +119,7 @@ def veff_and_expl_nuc_grad(
         )
     else:
         dExc_tuple = ()
-    dExc: dict[str, torch.Tensor] = {}
+    dExc: FeatureMap = {}
     for i in range(len(dExc_tuple)):
         dExc[nuc_feat_names[i]] = dExc_tuple[i].detach()
 
@@ -146,16 +147,16 @@ def veff_and_expl_nuc_grad(
         # Calculate the contribution to veff for this atomic grid
         veff_atm = torch.zeros((2, 3, nao, nao), dtype=rdm1.dtype, device=rdm1.device)
 
-        if "density" in nuc_grad_feats:
+        if Feature.DENSITY in nuc_grad_feats:
             veff_atm += torch.einsum(
                 "si, xip, iq -> sxpq",
-                dExc["density"][:, atm_start:atm_end],
+                dExc[Feature.DENSITY][:, atm_start:atm_end],
                 ao[1:4],
                 ao[0],
             )
 
-        if "grad" in nuc_grad_feats:
-            Exc_dgrad_atm = dExc["grad"][:, :, atm_start:atm_end]
+        if Feature.GRAD in nuc_grad_feats:
+            Exc_dgrad_atm = dExc[Feature.GRAD][:, :, atm_start:atm_end]
 
             veff_atm += torch.einsum(
                 "syi, xip, yiq -> sxpq", Exc_dgrad_atm, ao[1:4], ao[1:4]
@@ -191,8 +192,8 @@ def veff_and_expl_nuc_grad(
                 "si, ip, iq -> spq", Exc_dgrad_atm[:, 2], ao[9], ao[0]
             )
 
-        if "kin" in nuc_grad_feats:
-            Exc_dkin_atm = dExc["kin"][:, atm_start:atm_end]
+        if Feature.KIN in nuc_grad_feats:
+            Exc_dkin_atm = dExc[Feature.KIN][:, atm_start:atm_end]
             # XX, XY, XZ = 4, 5, 6
             veff_atm[:, 0] += (
                 torch.einsum("si, ip, iq -> spq", Exc_dkin_atm, ao[4], ao[1]) / 2
@@ -224,12 +225,12 @@ def veff_and_expl_nuc_grad(
                 torch.einsum("si, ip, iq -> spq", Exc_dkin_atm, ao[9], ao[3]) / 2
             )
 
-        if "grid_coords" in nuc_grad_feats:
+        if Feature.GRID_COORDS in nuc_grad_feats:
             # also add the explicit grid coordinate dependence
-            nuc_grad[atm_id] += dExc["grid_coords"][atm_start:atm_end].sum(dim=0)
+            nuc_grad[atm_id] += dExc[Feature.GRID_COORDS][atm_start:atm_end].sum(dim=0)
 
-        if "grid_weights" in nuc_grad_feats:
-            Exc_dgw = dExc["grid_weights"][atm_start:atm_end]
+        if Feature.GRID_WEIGHTS in nuc_grad_feats:
+            Exc_dgw = dExc[Feature.GRID_WEIGHTS][atm_start:atm_end]
             nuc_grad += from_dlpack(weight1) @ Exc_dgw
             # add the grid coordinate dependence via the density-like quantities to the nuclear gradient
             # we get those from the veff block. This tends to largely cancel with the grid_weights derivative,
@@ -242,8 +243,8 @@ def veff_and_expl_nuc_grad(
         veff += veff_atm
         atm_start = atm_end
 
-    if "coarse_0_atomic_coords" in nuc_grad_feats:
-        nuc_grad += dExc["coarse_0_atomic_coords"]
+    if Feature.COARSE_0_ATOMIC_COORDS in nuc_grad_feats:
+        nuc_grad += dExc[Feature.COARSE_0_ATOMIC_COORDS]
 
     # finalize
     if len(rdm1.shape) == 2:
@@ -270,7 +271,7 @@ def nuc_grad_from_veff(
 class SkalaRKSGradient(RHFGradient):  # type: ignore[misc]
     functional: ExcFunctionalBase
     """Skala functional"""
-    nuc_grad_feats: set[str] | None
+    nuc_grad_feats: set[Feature] | None
     """Which partial derivatives to take into account. None defaults to all."""
     veff_nuc_grad_: torch.Tensor | None
     """Contribution of the coordinate dependence of density, grad, kin, etc."""
@@ -281,7 +282,7 @@ class SkalaRKSGradient(RHFGradient):  # type: ignore[misc]
         self,
         ks: SCF,
         verbose: bool = False,
-        nuc_grad_feats: set[str] | None = None,
+        nuc_grad_feats: set[Feature] | None = None,
     ):
         super().__init__(ks)
         self.functional = ks._numint.func
@@ -369,7 +370,7 @@ class SkalaRKSGradient(RHFGradient):  # type: ignore[misc]
 class SkalaUKSGradient(UHFGradient):  # type: ignore[misc]
     functional: ExcFunctionalBase
     """Skala functional"""
-    nuc_grad_feats: set[str] | None
+    nuc_grad_feats: set[Feature] | None
     """Which partial derivatives to take into account. None defaults to all."""
     veff_nuc_grad_: torch.Tensor | None
     """Contribution of the coordinate dependence of density, grad, kin, etc."""
@@ -380,7 +381,7 @@ class SkalaUKSGradient(UHFGradient):  # type: ignore[misc]
         self,
         ks: SCF,
         verbose: bool = False,
-        nuc_grad_feats: set[str] | None = None,
+        nuc_grad_feats: set[Feature] | None = None,
     ):
         super().__init__(ks)
         self.functional = ks._numint.func

--- a/src/skala/pyscf/evaluation.py
+++ b/src/skala/pyscf/evaluation.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: MIT
+
+"""Feature requirements and numerical-evaluation policy."""
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from skala.features import Feature
+
+_AO_FEATURES = frozenset(
+    {
+        Feature.DENSITY,
+        Feature.GRAD,
+        Feature.KIN,
+        Feature.LAPL,
+    }
+)
+_ATOMIC_LAYOUT_FEATURES = frozenset(
+    {
+        Feature.ATOMIC_GRID_WEIGHTS,
+        Feature.ATOMIC_GRID_SIZES,
+        Feature.ATOMIC_GRID_SIZE_BOUND_SHAPE,
+    }
+)
+
+
+class FeatureSpec:
+    """Normalized feature names and their evaluation requirements."""
+
+    def __init__(self, names: Iterable[Feature]) -> None:
+        self._names = frozenset(names)
+
+    @property
+    def names(self) -> frozenset[Feature]:
+        """Return the normalized feature names."""
+        return self._names
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, FeatureSpec):
+            return NotImplemented
+        return self.names == other.names
+
+    def __hash__(self) -> int:
+        return hash(self.names)
+
+    def requests(self, feature: Feature) -> bool:
+        """Return whether a feature is requested."""
+        return feature in self.names
+
+    @property
+    def with_density(self) -> bool:
+        """Return whether density is requested."""
+        return self.requests(Feature.DENSITY)
+
+    @property
+    def with_grad(self) -> bool:
+        """Return whether the density gradient is requested."""
+        return self.requests(Feature.GRAD)
+
+    @property
+    def with_kin(self) -> bool:
+        """Return whether kinetic-energy density is requested."""
+        return self.requests(Feature.KIN)
+
+    @property
+    def with_lapl(self) -> bool:
+        """Return whether the density Laplacian is requested."""
+        return self.requests(Feature.LAPL)
+
+    @property
+    def requires_ao_evaluation(self) -> bool:
+        """Return whether AO-derived features are requested."""
+        return bool(self.names & _AO_FEATURES)
+
+    @property
+    def mgga_feature_count(self) -> int:
+        """Return the scalar width of the requested meta-GGA features."""
+        return self.with_density + 3 * self.with_grad + self.with_kin + self.with_lapl
+
+    @property
+    def ao_derivative_order(self) -> int:
+        """Return the highest AO derivative order needed by the features."""
+        if Feature.LAPL in self.names:
+            return 2
+        if self.names & {Feature.GRAD, Feature.KIN}:
+            return 1
+        return 0
+
+    @property
+    def requires_atomic_layout(self) -> bool:
+        """Return whether grid points must retain per-atom ordering."""
+        return bool(self.names & _ATOMIC_LAYOUT_FEATURES)
+
+    @property
+    def supports_spatial_decomposition(self) -> bool:
+        """Return whether spatial decomposition is supported."""
+        return Feature.ATOMIC_GRID_SIZES in self.names
+
+
+@dataclass(frozen=True)
+class EvaluationPolicy:
+    """Settings shared by dense and screened AO feature evaluation."""
+
+    ao_block_size: int | None = None
+    safety_fraction: float = 0.8

--- a/src/skala/pyscf/features.py
+++ b/src/skala/pyscf/features.py
@@ -16,6 +16,7 @@ from torch import Tensor, nn
 from torch.autograd import Function
 from torch.autograd.function import FunctionCtx
 
+from skala.features import Feature, FeatureMap
 from skala.pyscf.backend import (
     Array,
     Grid,
@@ -27,14 +28,20 @@ from skala.pyscf.memory_estimators import estimate_max_grid_chunk_size
 
 LOG = logging.getLogger(__name__)
 
-DEFAULT_FEATURES = ["density", "kin", "grad", "grid_coords", "grid_weights"]
+DEFAULT_FEATURES = [
+    Feature.DENSITY,
+    Feature.KIN,
+    Feature.GRAD,
+    Feature.GRID_COORDS,
+    Feature.GRID_WEIGHTS,
+]
 DEFAULT_FEATURES_SET = set(DEFAULT_FEATURES)
 
 # Features that require per-atom grid decomposition.
 _ATOMIC_GRID_FEATURES = {
-    "atomic_grid_weights",
-    "atomic_grid_sizes",
-    "atomic_grid_size_bound_shape",
+    Feature.ATOMIC_GRID_WEIGHTS,
+    Feature.ATOMIC_GRID_SIZES,
+    Feature.ATOMIC_GRID_SIZE_BOUND_SHAPE,
 }
 
 
@@ -54,12 +61,12 @@ def chunked_features(
     mol: gto.Mole,
     dm: Tensor,
     grids: Grid,
-    features: set[str],
+    features: set[Feature],
     func_deriv: int,
     max_memory_in_mb: int | None = None,
     safety_fraction: float = 0.8,
     compile_feature_function: bool = False,
-) -> Iterator[dict[str, Tensor]]:
+) -> Iterator[FeatureMap]:
     """
     Chunked feature generation for a given molecule. The density features are generated in chunks to avoid memory issues.
 
@@ -155,7 +162,7 @@ def chunked_features(
             for k, v in ff.to_dict(feat_tensor).items():
                 feature_chunk[k] = maybe_expand_and_divide(v, not with_spin, 2)
 
-        yield feature_chunk
+        yield {Feature(name): value for name, value in feature_chunk.items()}
 
 
 def make_chunks(
@@ -212,11 +219,11 @@ def generate_features(
     mol: gto.Mole,
     dm: Tensor,
     grids: Grid,
-    features: set[str] | None = None,
+    features: set[Feature] | None = None,
     chunk_size: int | None = None,
     max_memory: int = 2000,
     gpu: bool = False,
-) -> dict[str, Tensor]:
+) -> FeatureMap:
     """Generate density features for a given molecule. The density features are stored in a dictionary
     with the keys matching the requested features.
 
@@ -281,14 +288,14 @@ def generate_features(
                 mgga_features[feature], not with_spin, 2
             )
 
-    return mol_features
+    return {Feature(name): value for name, value in mol_features.items()}
 
 
 def get_grid_features(
     mol: gto.Mole,
     dm: Tensor,
     grids: Grid,
-    requested_features: set[str],
+    requested_features: set[Feature],
 ) -> dict[str, Tensor]:
     grid_features = {}
 

--- a/src/skala/pyscf/gradients.py
+++ b/src/skala/pyscf/gradients.py
@@ -15,6 +15,7 @@ from pyscf.grad.uks import Gradients as UHFGradient
 from pyscf.scf.hf import SCF
 
 import skala.pyscf.features as feature
+from skala.features import Feature, FeatureMap
 from skala.functional.base import ExcFunctionalBase
 
 LOG = logging.getLogger(__name__)
@@ -25,7 +26,7 @@ def veff_and_expl_nuc_grad(
     mol: gto.Mole,
     grid: dft.Grids,
     rdm1: torch.Tensor,
-    nuc_grad_feats: set[str] | None = None,
+    nuc_grad_feats: set[Feature] | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
     returns:
@@ -34,21 +35,21 @@ def veff_and_expl_nuc_grad(
     """
 
     SUPPORTED_FEATS = {
-        "density",
-        "grad",
-        "kin",
-        "grid_coords",
-        "grid_weights",
-        "atomic_grid_weights",
-        "coarse_0_atomic_coords",
+        Feature.DENSITY,
+        Feature.GRAD,
+        Feature.KIN,
+        Feature.GRID_COORDS,
+        Feature.GRID_WEIGHTS,
+        Feature.ATOMIC_GRID_WEIGHTS,
+        Feature.COARSE_0_ATOMIC_COORDS,
     }
 
     if nuc_grad_feats is None:  # generate feature list from functional features
         nuc_grad_feats = set(functional.features)
 
     # Integer-valued features have no nuclear gradient — always discard them
-    nuc_grad_feats.discard("atomic_grid_sizes")
-    nuc_grad_feats.discard("atomic_grid_size_bound_shape")
+    nuc_grad_feats.discard(Feature.ATOMIC_GRID_SIZES)
+    nuc_grad_feats.discard(Feature.ATOMIC_GRID_SIZE_BOUND_SHAPE)
 
     # check for unsupported features
     unsupported_feats = {feat for feat in nuc_grad_feats if feat not in SUPPORTED_FEATS}
@@ -60,9 +61,9 @@ def veff_and_expl_nuc_grad(
     LOG.debug("nuc_grad_feats = %s", nuc_grad_feats)
 
     # determine the maximum ao derivative needed
-    if "grad" in nuc_grad_feats or "kin" in nuc_grad_feats:
+    if Feature.GRAD in nuc_grad_feats or Feature.KIN in nuc_grad_feats:
         ao_deriv = 2
-    elif "density" in nuc_grad_feats:
+    elif Feature.DENSITY in nuc_grad_feats:
         ao_deriv = 1
     else:
         ao_deriv = 0
@@ -82,13 +83,13 @@ def veff_and_expl_nuc_grad(
     # Discard atomic_grid_weights from VJP features: d(atomic_grid_weights)/dR = 0
     # because they are raw quadrature weights that depend only on the radial/angular
     # grid rule, not on nuclear positions. They still pass through as other_feats.
-    nuc_grad_feats.discard("atomic_grid_weights")
+    nuc_grad_feats.discard(Feature.ATOMIC_GRID_WEIGHTS)
 
     # Get required derivatives
     nuc_feat_names = list(nuc_grad_feats)  # ensure specific order
     nuc_feat_tensors = [mol_feats[feat] for feat in nuc_feat_names]
     other_feats = {
-        feat: mol_feats[feat] for feat in mol_feats.keys() if feat not in nuc_grad_feats
+        feat: mol_feats[feat] for feat in mol_feats if feat not in nuc_grad_feats
     }
 
     def exc_feat_func(*nuc_feat_tensors: torch.Tensor) -> torch.Tensor:
@@ -99,7 +100,7 @@ def veff_and_expl_nuc_grad(
 
     _, dExc_func = torch.func.vjp(exc_feat_func, *nuc_feat_tensors)
     dExc_tuple = dExc_func(torch.tensor(1.0, dtype=rdm1.dtype))
-    dExc: dict[str, torch.Tensor] = {}
+    dExc: FeatureMap = {}
     for i in range(len(dExc_tuple)):
         dExc[nuc_feat_names[i]] = dExc_tuple[i].detach()
 
@@ -124,16 +125,16 @@ def veff_and_expl_nuc_grad(
         # Calculate the contribution to veff for this atomic grid
         veff_atm = torch.zeros((2, 3, nao, nao), dtype=rdm1.dtype)
 
-        if "density" in nuc_grad_feats:
+        if Feature.DENSITY in nuc_grad_feats:
             veff_atm += torch.einsum(
                 "si, xip, iq -> sxpq",
-                dExc["density"][:, atm_start:atm_end],
+                dExc[Feature.DENSITY][:, atm_start:atm_end],
                 ao[1:4],
                 ao[0],
             )
 
-        if "grad" in nuc_grad_feats:
-            Exc_dgrad_atm = dExc["grad"][:, :, atm_start:atm_end]
+        if Feature.GRAD in nuc_grad_feats:
+            Exc_dgrad_atm = dExc[Feature.GRAD][:, :, atm_start:atm_end]
 
             veff_atm += torch.einsum(
                 "syi, xip, yiq -> sxpq", Exc_dgrad_atm, ao[1:4], ao[1:4]
@@ -169,8 +170,8 @@ def veff_and_expl_nuc_grad(
                 "si, ip, iq -> spq", Exc_dgrad_atm[:, 2], ao[9], ao[0]
             )
 
-        if "kin" in nuc_grad_feats:
-            Exc_dkin_atm = dExc["kin"][:, atm_start:atm_end]
+        if Feature.KIN in nuc_grad_feats:
+            Exc_dkin_atm = dExc[Feature.KIN][:, atm_start:atm_end]
             # XX, XY, XZ = 4, 5, 6
             veff_atm[:, 0] += (
                 torch.einsum("si, ip, iq -> spq", Exc_dkin_atm, ao[4], ao[1]) / 2
@@ -202,12 +203,12 @@ def veff_and_expl_nuc_grad(
                 torch.einsum("si, ip, iq -> spq", Exc_dkin_atm, ao[9], ao[3]) / 2
             )
 
-        if "grid_coords" in nuc_grad_feats:
+        if Feature.GRID_COORDS in nuc_grad_feats:
             # also add the explicit grid coordinate dependence
-            nuc_grad[atm_id] += dExc["grid_coords"][atm_start:atm_end].sum(dim=0)
+            nuc_grad[atm_id] += dExc[Feature.GRID_COORDS][atm_start:atm_end].sum(dim=0)
 
-        if "grid_weights" in nuc_grad_feats:
-            Exc_dgw = dExc["grid_weights"][atm_start:atm_end]
+        if Feature.GRID_WEIGHTS in nuc_grad_feats:
+            Exc_dgw = dExc[Feature.GRID_WEIGHTS][atm_start:atm_end]
             nuc_grad += torch.from_numpy(weight1) @ Exc_dgw
             # add the grid coordinate dependence via the density-like quantities to the nuclear gradient
             # we get those from the veff block. This tends to largely cancel with the grid_weights derivative,
@@ -220,8 +221,8 @@ def veff_and_expl_nuc_grad(
         veff += veff_atm
         atm_start = atm_end
 
-    if "coarse_0_atomic_coords" in nuc_grad_feats:
-        nuc_grad += dExc["coarse_0_atomic_coords"]
+    if Feature.COARSE_0_ATOMIC_COORDS in nuc_grad_feats:
+        nuc_grad += dExc[Feature.COARSE_0_ATOMIC_COORDS]
 
     # finalize
     if len(rdm1.shape) == 2:
@@ -235,7 +236,7 @@ def veff_and_expl_nuc_grad(
 class SkalaRKSGradient(RHFGradient):  # type: ignore[misc]
     functional: ExcFunctionalBase
     """LivDFT functional"""
-    nuc_grad_feats: set[str] | None
+    nuc_grad_feats: set[Feature] | None
     """Which partial derivatives to take into account. None defaults to all."""
     veff_nuc_grad_: torch.Tensor
     """Contribution of the coordinate dependence of density, grad, kin, etc."""
@@ -246,7 +247,7 @@ class SkalaRKSGradient(RHFGradient):  # type: ignore[misc]
         self,
         ks: SCF,
         verbose: bool = False,
-        nuc_grad_feats: set[str] | None = None,
+        nuc_grad_feats: set[Feature] | None = None,
     ):
         super().__init__(ks)
         self.functional = ks._numint.func
@@ -312,7 +313,7 @@ class SkalaRKSGradient(RHFGradient):  # type: ignore[misc]
 class SkalaUKSGradient(UHFGradient):  # type: ignore[misc]
     functional: ExcFunctionalBase
     """LivDFT functional"""
-    nuc_grad_feats: set[str] | None
+    nuc_grad_feats: set[Feature] | None
     """Which partial derivatives to take into account. None defaults to all."""
     veff_nuc_grad_: torch.Tensor
     """Contribution of the coordinate dependence of density, grad, kin, etc."""
@@ -323,7 +324,7 @@ class SkalaUKSGradient(UHFGradient):  # type: ignore[misc]
         self,
         ks: SCF,
         verbose: bool = False,
-        nuc_grad_feats: set[str] | None = None,
+        nuc_grad_feats: set[Feature] | None = None,
     ):
         super().__init__(ks)
         self.functional = ks._numint.func

--- a/src/skala/pyscf/numint.py
+++ b/src/skala/pyscf/numint.py
@@ -7,6 +7,7 @@ import torch
 from pyscf import dft, gto
 from torch import Tensor
 
+from skala.features import Feature
 from skala.functional.base import ExcFunctionalBase
 from skala.pyscf.backend import (
     KS,
@@ -155,12 +156,12 @@ class SkalaNumInt(PySCFNumInt[Array]):
             mol,
             self.from_backend(dm),
             grids,
-            features={"density"},
+            features={Feature.DENSITY},
             chunk_size=self.chunk_size,
             max_memory=max_memory,
             gpu=self.device.type == "cuda",
         )
-        return self.to_backend(mol_features["density"].sum(0))  # type: ignore
+        return self.to_backend(mol_features[Feature.DENSITY].sum(0))  # type: ignore
 
     def __call__(
         self,
@@ -211,7 +212,7 @@ class SkalaNumInt(PySCFNumInt[Array]):
                     torch.ones_like(E_xc_chunk),
                 )
                 tot_dens += (
-                    (mol_features["density"] * mol_features["grid_weights"])
+                    (mol_features[Feature.DENSITY] * mol_features[Feature.GRID_WEIGHTS])
                     .sum(dim=-1)
                     .detach()
                 )
@@ -240,9 +241,9 @@ class SkalaNumInt(PySCFNumInt[Array]):
                 create_graph=second_order,
             )
 
-            rho = mol_features["density"]
+            rho = mol_features[Feature.DENSITY]
             grid_weights = mol_features.get(
-                "grid_weights", self.from_backend(grids.weights)
+                Feature.GRID_WEIGHTS, self.from_backend(grids.weights)
             )
             tot_dens = (rho * grid_weights).sum(dim=-1)
             return tot_dens, E_xc, V_xc

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,69 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from skala.features import Feature
+from skala.pyscf.evaluation import EvaluationPolicy, FeatureSpec
+
+
+def test_feature_name_parses_model_metadata_string() -> None:
+    assert Feature("density") is Feature.DENSITY
+
+
+@pytest.mark.parametrize(
+    ("features", "expected_order"),
+    [
+        ([], 0),
+        ([Feature.DENSITY], 0),
+        ([Feature.GRAD], 1),
+        ([Feature.KIN], 1),
+        ([Feature.LAPL], 2),
+        (
+            [
+                Feature.DENSITY,
+                Feature.GRAD,
+                Feature.KIN,
+                Feature.LAPL,
+            ],
+            2,
+        ),
+    ],
+)
+def test_feature_spec_derives_mgga_requirements(
+    features: list[Feature], expected_order: int
+) -> None:
+    spec = FeatureSpec(features)
+
+    assert spec.requires_ao_evaluation is bool(features)
+    assert spec.ao_derivative_order == expected_order
+    assert spec.with_density is (Feature.DENSITY in features)
+    assert spec.with_grad is (Feature.GRAD in features)
+    assert spec.with_kin is (Feature.KIN in features)
+    assert spec.with_lapl is (Feature.LAPL in features)
+
+
+@pytest.mark.parametrize(
+    ("feature", "supports_screened_evaluation"),
+    [
+        (Feature.ATOMIC_GRID_WEIGHTS, False),
+        (Feature.ATOMIC_GRID_SIZES, True),
+        (Feature.ATOMIC_GRID_SIZE_BOUND_SHAPE, False),
+    ],
+)
+def test_feature_spec_derives_atomic_layout_requirements(
+    feature: Feature, supports_screened_evaluation: bool
+) -> None:
+    spec = FeatureSpec([feature, feature])
+
+    assert spec.names == frozenset({feature})
+    assert spec.requires_atomic_layout
+    assert spec.supports_spatial_decomposition is supports_screened_evaluation
+
+
+def test_evaluation_policy_defaults_and_is_immutable() -> None:
+    policy = EvaluationPolicy()
+
+    assert policy.ao_block_size is None
+    assert policy.safety_fraction == 0.8
+    with pytest.raises(FrozenInstanceError):
+        policy.safety_fraction = 0.5  # type: ignore[misc]

--- a/tests/test_gpu4pyscf_gradients.py
+++ b/tests/test_gpu4pyscf_gradients.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 
 import pytest
 import torch
+from torch.utils.dlpack import from_dlpack
 
 if not torch.cuda.is_available():
     pytest.skip(
@@ -16,21 +17,22 @@ except ModuleNotFoundError:
         allow_module_level=True,
     )
 
-from _ridders import num_grad_ridders
-from gpu4pyscf import dft, scf
-from pyscf import gto
-from test_pyscf_gradients import FULL_GRAD_REF
+from _ridders import num_grad_ridders  # noqa: E402
+from gpu4pyscf import dft, scf  # noqa: E402
+from pyscf import gto  # noqa: E402
+from test_pyscf_gradients import FULL_GRAD_REF  # noqa: E402
 
-from skala.functional.base import ExcFunctionalBase
-from skala.gpu4pyscf import SkalaKS
-from skala.gpu4pyscf.gradients import (
+from skala.features import Feature, FeatureMap  # noqa: E402
+from skala.functional.base import ExcFunctionalBase  # noqa: E402
+from skala.gpu4pyscf import SkalaKS  # noqa: E402
+from skala.gpu4pyscf.gradients import (  # noqa: E402
     SkalaRKSGradient,
     SkalaUKSGradient,
     nuc_grad_from_veff,
     veff_and_expl_nuc_grad,
 )
-from skala.pyscf.features import generate_features
-from skala.utils import torch_allocator
+from skala.pyscf.features import generate_features  # noqa: E402
+from skala.utils import torch_allocator  # noqa: E402
 
 
 def test_torch_allocator_is_active_after_import() -> None:
@@ -102,7 +104,7 @@ def get_grid_and_rdm1(mol: gto.Mole) -> tuple[dft.Grids, torch.Tensor]:
         grids=minimal_grid(mol),
     )
     mf.kernel()
-    rdm1 = torch.from_dlpack(mf.make_rdm1())  # type: ignore[attr-defined]
+    rdm1 = from_dlpack(mf.make_rdm1())
     return mf.grids, rdm1  # maybe_expand_and_divide(rdm1, len(rdm1.shape) == 2, 2)
 
 
@@ -110,11 +112,11 @@ def test_grid_coords_gradient(mol_name: str) -> None:
     class TestFunc(ExcFunctionalBase):
         def __init__(self) -> None:
             super().__init__()
-            self.features = ["grid_coords"]
+            self.features = [Feature.GRID_COORDS]
 
-        def get_exc(self, mol: dict[str, torch.Tensor]) -> torch.Tensor:
+        def get_exc(self, mol: FeatureMap) -> torch.Tensor:
             """This actually calculates the total electron number"""
-            return mol["grid_coords"].sum()
+            return mol[Feature.GRID_COORDS].sum()
 
     mol = get_mol(mol_name)
     grid, rdm1 = get_grid_and_rdm1(mol)
@@ -137,11 +139,11 @@ def test_coarse_0_atomic_coords_gradient(mol_name: str) -> None:
     class TestFunc(ExcFunctionalBase):
         def __init__(self) -> None:
             super().__init__()
-            self.features = ["coarse_0_atomic_coords"]
+            self.features = [Feature.COARSE_0_ATOMIC_COORDS]
 
-        def get_exc(self, mol: dict[str, torch.Tensor]) -> torch.Tensor:
+        def get_exc(self, mol: FeatureMap) -> torch.Tensor:
             """This actually calculates the total electron number"""
-            return torch.einsum("nx->", mol["coarse_0_atomic_coords"])
+            return torch.einsum("nx->", mol[Feature.COARSE_0_ATOMIC_COORDS])
 
     mol = get_mol(mol_name)
     grid, rdm1 = get_grid_and_rdm1(mol)
@@ -160,11 +162,11 @@ def test_grid_weights_gradient(mol_name: str) -> None:
     class TestFunc(ExcFunctionalBase):
         def __init__(self) -> None:
             super().__init__()
-            self.features = ["grid_weights"]
+            self.features = [Feature.GRID_WEIGHTS]
 
-        def get_exc(self, mol: dict[str, torch.Tensor]) -> torch.Tensor:
+        def get_exc(self, mol: FeatureMap) -> torch.Tensor:
             """This actually calculates the total electron number"""
-            return mol["grid_weights"].sum()
+            return mol[Feature.GRID_WEIGHTS].sum()
 
     def finite_difference_nuc_grad(
         weight_sum: ExcFunctionalBase, mol: gto.Mole, rdm1: torch.Tensor
@@ -178,7 +180,7 @@ def test_grid_weights_gradient(mol_name: str) -> None:
         def weight_sum_as_nuc_coords_func(nuc_coords: torch.Tensor) -> torch.Tensor:
             """Exc wrapper for the finite difference"""
             mol.set_geom_(nuc_coords.cpu().numpy(), "bohr", symmetry=None)
-            mol_feats["grid_weights"] = torch.from_dlpack(minimal_grid(mol).weights)  # type: ignore[attr-defined]
+            mol_feats[Feature.GRID_WEIGHTS] = from_dlpack(minimal_grid(mol).weights)
 
             return weight_sum.get_exc(mol_feats)
 
@@ -193,7 +195,7 @@ def test_grid_weights_gradient(mol_name: str) -> None:
     num_grad, num_err = finite_difference_nuc_grad(exc_test, mol, rdm1)
     # estimate the minimum expected absolute error
     eps = (
-        exc_test.get_exc({"grid_weights": torch.from_dlpack(grid.weights)})  # type: ignore[attr-defined]
+        exc_test.get_exc({Feature.GRID_WEIGHTS: from_dlpack(grid.weights)})
         * torch.finfo(num_grad.dtype).eps
     )
 
@@ -212,11 +214,11 @@ def test_density_veff(mol_name: str) -> None:
     class TestFunc(ExcFunctionalBase):
         def __init__(self) -> None:
             super().__init__()
-            self.features = ["density", "grid_weights"]
+            self.features = [Feature.DENSITY, Feature.GRID_WEIGHTS]
 
-        def get_exc(self, mol: dict[str, torch.Tensor]) -> torch.Tensor:
+        def get_exc(self, mol: FeatureMap) -> torch.Tensor:
             """This actually calculates the total electron number"""
-            return (mol["density"] @ mol["grid_weights"]).sum()
+            return (mol[Feature.DENSITY] @ mol[Feature.GRID_WEIGHTS]).sum()
 
     def finite_difference_nuc_grad(
         dens_sum: ExcFunctionalBase, mol: gto.Mole, rdm1: torch.Tensor
@@ -246,7 +248,7 @@ def test_density_veff(mol_name: str) -> None:
 
     # calculate analytic result
     veff = veff_and_expl_nuc_grad(
-        exc_test, mol, grid, rdm1, nuc_grad_feats={"density"}
+        exc_test, mol, grid, rdm1, nuc_grad_feats={Feature.DENSITY}
     )[0]
     ana_grad = 2 * nuc_grad_from_veff(mol, veff, rdm1)
 
@@ -267,15 +269,15 @@ def test_grad_veff(mol_name: str) -> None:
     class TestFunc(ExcFunctionalBase):
         def __init__(self) -> None:
             super().__init__()
-            self.features = ["grad", "grid_weights"]
+            self.features = [Feature.GRAD, Feature.GRID_WEIGHTS]
 
-        def get_exc(self, mol: dict[str, torch.Tensor]) -> torch.Tensor:
+        def get_exc(self, mol: FeatureMap) -> torch.Tensor:
             return (
-                (mol["grad"] ** 2 @ mol["grid_weights"])
+                (mol[Feature.GRAD] ** 2 @ mol[Feature.GRID_WEIGHTS])
                 @ torch.tensor(
                     [1.0, 2.0, 3.0],
                     dtype=torch.float64,
-                    device=mol["grad"].device,
+                    device=mol[Feature.GRAD].device,
                 )
             ).sum()
 
@@ -307,7 +309,9 @@ def test_grad_veff(mol_name: str) -> None:
     num_grad, num_err = finite_difference_nuc_grad(exc_test, mol, rdm1)
 
     # calculate analytic result
-    veff = veff_and_expl_nuc_grad(exc_test, mol, grid, rdm1, nuc_grad_feats={"grad"})[0]
+    veff = veff_and_expl_nuc_grad(
+        exc_test, mol, grid, rdm1, nuc_grad_feats={Feature.GRAD}
+    )[0]
     ana_grad = 2 * nuc_grad_from_veff(mol, veff, rdm1)
 
     check_mat = (ana_grad - num_grad).abs() <= torch.max(
@@ -327,11 +331,11 @@ def test_kin_veff(mol_name: str) -> None:
     class TestFunc(ExcFunctionalBase):
         def __init__(self) -> None:
             super().__init__()
-            self.features = ["kin", "grid_weights"]
+            self.features = [Feature.KIN, Feature.GRID_WEIGHTS]
 
-        def get_exc(self, mol: dict[str, torch.Tensor]) -> torch.Tensor:
+        def get_exc(self, mol: FeatureMap) -> torch.Tensor:
             """This actually calculates the total kinetic energy number"""
-            return (mol["kin"] @ mol["grid_weights"]).sum()
+            return (mol[Feature.KIN] @ mol[Feature.GRID_WEIGHTS]).sum()
 
     def finite_difference_nuc_grad(
         kin_func: ExcFunctionalBase, mol: gto.Mole, rdm1: torch.Tensor
@@ -361,7 +365,9 @@ def test_kin_veff(mol_name: str) -> None:
     num_grad, num_err = finite_difference_nuc_grad(exc_test, mol, rdm1)
 
     # calculate analytic result
-    veff = veff_and_expl_nuc_grad(exc_test, mol, grid, rdm1, nuc_grad_feats={"kin"})[0]
+    veff = veff_and_expl_nuc_grad(
+        exc_test, mol, grid, rdm1, nuc_grad_feats={Feature.KIN}
+    )[0]
     ana_grad = 2 * nuc_grad_from_veff(mol, veff, rdm1)
 
     check_mat = (ana_grad - num_grad).abs() <= torch.max(
@@ -448,15 +454,15 @@ def test_cuda_kernel_memory_stability() -> None:
     class TestFunc(ExcFunctionalBase):
         def __init__(self) -> None:
             super().__init__()
-            self.features = ["grad", "grid_weights"]
+            self.features = [Feature.GRAD, Feature.GRID_WEIGHTS]
 
-        def get_exc(self, mol: dict[str, torch.Tensor]) -> torch.Tensor:
+        def get_exc(self, mol: FeatureMap) -> torch.Tensor:
             return (
-                (mol["grad"] ** 2 @ mol["grid_weights"])
+                (mol[Feature.GRAD] ** 2 @ mol[Feature.GRID_WEIGHTS])
                 @ torch.tensor(
                     [1.0, 2.0, 3.0],
                     dtype=torch.float64,
-                    device=mol["grad"].device,
+                    device=mol[Feature.GRAD].device,
                 )
             ).sum()
 
@@ -465,7 +471,7 @@ def test_cuda_kernel_memory_stability() -> None:
     # Warmup to avoid counting one-time allocations from CUDA runtime/libraries.
     for _ in range(2):
         veff = veff_and_expl_nuc_grad(
-            exc_test, mol, grid, rdm1, nuc_grad_feats={"grad"}
+            exc_test, mol, grid, rdm1, nuc_grad_feats={Feature.GRAD}
         )[0]
         _ = 2 * nuc_grad_from_veff(mol, veff, rdm1)
 
@@ -476,7 +482,7 @@ def test_cuda_kernel_memory_stability() -> None:
     torch.cuda.reset_peak_memory_stats()
     for _ in range(5):
         veff = veff_and_expl_nuc_grad(
-            exc_test, mol, grid, rdm1, nuc_grad_feats={"grad"}
+            exc_test, mol, grid, rdm1, nuc_grad_feats={Feature.GRAD}
         )[0]
         _ = 2 * nuc_grad_from_veff(mol, veff, rdm1)
         torch.cuda.synchronize()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -15,6 +15,7 @@ from collections.abc import Callable, Iterator
 import pytest
 import torch
 
+from skala.features import Feature, FeatureMap
 from skala.functional import ExcFunctionalBase
 from skala.functional.model import (
     ANGSTROM_TO_BOHR,
@@ -53,22 +54,24 @@ def make_mol(
     grid_per_atom: int,
     device: str = "cpu",
     dtype: torch.dtype = torch.float64,
-) -> dict[str, torch.Tensor]:
+) -> FeatureMap:
     total_grid = num_atoms * grid_per_atom
     return {
-        "density": torch.randn(2, total_grid, dtype=dtype, device=device),
-        "grad": torch.randn(2, 3, total_grid, dtype=dtype, device=device),
-        "kin": torch.randn(2, total_grid, dtype=dtype, device=device),
-        "grid_coords": torch.randn(total_grid, 3, dtype=dtype, device=device),
-        "grid_weights": torch.randn(total_grid, dtype=dtype, device=device).abs(),
-        "atomic_grid_weights": torch.randn(
+        Feature.DENSITY: torch.randn(2, total_grid, dtype=dtype, device=device),
+        Feature.GRAD: torch.randn(2, 3, total_grid, dtype=dtype, device=device),
+        Feature.KIN: torch.randn(2, total_grid, dtype=dtype, device=device),
+        Feature.GRID_COORDS: torch.randn(total_grid, 3, dtype=dtype, device=device),
+        Feature.GRID_WEIGHTS: torch.randn(total_grid, dtype=dtype, device=device).abs(),
+        Feature.ATOMIC_GRID_WEIGHTS: torch.randn(
             total_grid, dtype=dtype, device=device
         ).abs(),
-        "atomic_grid_sizes": torch.tensor(
+        Feature.ATOMIC_GRID_SIZES: torch.tensor(
             [grid_per_atom] * num_atoms, dtype=torch.int64, device=device
         ),
-        "coarse_0_atomic_coords": torch.randn(num_atoms, 3, dtype=dtype, device=device),
-        "atomic_grid_size_bound_shape": torch.zeros(
+        Feature.COARSE_0_ATOMIC_COORDS: torch.randn(
+            num_atoms, 3, dtype=dtype, device=device
+        ),
+        Feature.ATOMIC_GRID_SIZE_BOUND_SHAPE: torch.zeros(
             grid_per_atom, 0, dtype=torch.int64, device=device
         ),
     }
@@ -78,24 +81,26 @@ def make_mol_variable_grid(
     atomic_grid_sizes: list[int],
     device: str = "cpu",
     dtype: torch.dtype = torch.float64,
-) -> dict[str, torch.Tensor]:
+) -> FeatureMap:
     """Create a mol dict with variable grid sizes per atom."""
     sizes = torch.tensor(atomic_grid_sizes, dtype=torch.int64, device=device)
     num_atoms = len(atomic_grid_sizes)
     total_grid = sum(atomic_grid_sizes)
     size_bound = max(atomic_grid_sizes)
     return {
-        "density": torch.randn(2, total_grid, dtype=dtype, device=device),
-        "grad": torch.randn(2, 3, total_grid, dtype=dtype, device=device),
-        "kin": torch.randn(2, total_grid, dtype=dtype, device=device),
-        "grid_coords": torch.randn(total_grid, 3, dtype=dtype, device=device),
-        "grid_weights": torch.randn(total_grid, dtype=dtype, device=device).abs(),
-        "atomic_grid_weights": torch.randn(
+        Feature.DENSITY: torch.randn(2, total_grid, dtype=dtype, device=device),
+        Feature.GRAD: torch.randn(2, 3, total_grid, dtype=dtype, device=device),
+        Feature.KIN: torch.randn(2, total_grid, dtype=dtype, device=device),
+        Feature.GRID_COORDS: torch.randn(total_grid, 3, dtype=dtype, device=device),
+        Feature.GRID_WEIGHTS: torch.randn(total_grid, dtype=dtype, device=device).abs(),
+        Feature.ATOMIC_GRID_WEIGHTS: torch.randn(
             total_grid, dtype=dtype, device=device
         ).abs(),
-        "atomic_grid_sizes": sizes,
-        "coarse_0_atomic_coords": torch.randn(num_atoms, 3, dtype=dtype, device=device),
-        "atomic_grid_size_bound_shape": torch.zeros(
+        Feature.ATOMIC_GRID_SIZES: sizes,
+        Feature.COARSE_0_ATOMIC_COORDS: torch.randn(
+            num_atoms, 3, dtype=dtype, device=device
+        ),
+        Feature.ATOMIC_GRID_SIZE_BOUND_SHAPE: torch.zeros(
             size_bound, 0, dtype=torch.int64, device=device
         ),
     }
@@ -183,21 +188,21 @@ def test_pack_features_snapshot() -> None:
     mol = make_mol(4, 10)
     packed = model.pack_features(mol)
 
-    assert packed["density"].shape == (2, 10, 4)
-    assert packed["kin"].shape == (2, 10, 4)
-    assert packed["grad"].shape == (2, 3, 10, 4)
-    assert packed["grid_coords"].shape == (10, 4, 3)
-    assert packed["atomic_grid_weights"].shape == (10, 4)
-    assert packed["coarse_0_atomic_coords"].shape == (4, 3)
+    assert packed[Feature.DENSITY].shape == (2, 10, 4)
+    assert packed[Feature.KIN].shape == (2, 10, 4)
+    assert packed[Feature.GRAD].shape == (2, 3, 10, 4)
+    assert packed[Feature.GRID_COORDS].shape == (10, 4, 3)
+    assert packed[Feature.ATOMIC_GRID_WEIGHTS].shape == (10, 4)
+    assert packed[Feature.COARSE_0_ATOMIC_COORDS].shape == (4, 3)
 
     torch.testing.assert_close(
-        packed["density"].sum(),
+        packed[Feature.DENSITY].sum(),
         torch.tensor(1.020635438470402e01, dtype=torch.float64),
         rtol=1e-5,
         atol=1e-5,
     )
     torch.testing.assert_close(
-        packed["atomic_grid_weights"].sum(),
+        packed[Feature.ATOMIC_GRID_WEIGHTS].sum(),
         torch.tensor(4.032819661608873e01, dtype=torch.float64),
         rtol=1e-5,
         atol=1e-5,

--- a/tests/test_pyscf_gradients.py
+++ b/tests/test_pyscf_gradients.py
@@ -5,6 +5,7 @@ import torch
 from _ridders import num_grad_ridders
 from pyscf import dft, gto, scf
 
+from skala.features import Feature, FeatureMap
 from skala.functional.base import ExcFunctionalBase
 from skala.pyscf import SkalaKS
 from skala.pyscf.features import generate_features
@@ -58,11 +59,11 @@ def test_grid_coords_gradient(mol_name: str) -> None:
     class TestFunc(ExcFunctionalBase):
         def __init__(self) -> None:
             super().__init__()
-            self.features = ["grid_coords"]
+            self.features = [Feature.GRID_COORDS]
 
-        def get_exc(self, mol: dict[str, torch.Tensor]) -> torch.Tensor:
+        def get_exc(self, mol: FeatureMap) -> torch.Tensor:
             """This actually calculates the total electron number"""
-            return mol["grid_coords"].sum()
+            return mol[Feature.GRID_COORDS].sum()
 
     mol = get_mol(mol_name)
     grid, rdm1 = get_grid_and_rdm1(mol)
@@ -85,11 +86,11 @@ def test_coarse_0_atomic_coords_gradient(mol_name: str) -> None:
     class TestFunc(ExcFunctionalBase):
         def __init__(self) -> None:
             super().__init__()
-            self.features = ["coarse_0_atomic_coords"]
+            self.features = [Feature.COARSE_0_ATOMIC_COORDS]
 
-        def get_exc(self, mol: dict[str, torch.Tensor]) -> torch.Tensor:
+        def get_exc(self, mol: FeatureMap) -> torch.Tensor:
             """This actually calculates the total electron number"""
-            return torch.einsum("nx->", mol["coarse_0_atomic_coords"])
+            return torch.einsum("nx->", mol[Feature.COARSE_0_ATOMIC_COORDS])
 
     mol = get_mol(mol_name)
     grid, rdm1 = get_grid_and_rdm1(mol)
@@ -108,11 +109,11 @@ def test_grid_weights_gradient(mol_name: str) -> None:
     class TestFunc(ExcFunctionalBase):
         def __init__(self) -> None:
             super().__init__()
-            self.features = ["grid_weights"]
+            self.features = [Feature.GRID_WEIGHTS]
 
-        def get_exc(self, mol: dict[str, torch.Tensor]) -> torch.Tensor:
+        def get_exc(self, mol: FeatureMap) -> torch.Tensor:
             """This actually calculates the total electron number"""
-            return mol["grid_weights"].sum()
+            return mol[Feature.GRID_WEIGHTS].sum()
 
     def finite_difference_nuc_grad(
         weight_sum: ExcFunctionalBase, mol: gto.Mole, rdm1: torch.Tensor
@@ -126,7 +127,9 @@ def test_grid_weights_gradient(mol_name: str) -> None:
         def weight_sum_as_nuc_coords_func(nuc_coords: torch.Tensor) -> torch.Tensor:
             """Exc wrapper for the finite difference"""
             mol.set_geom_(nuc_coords.numpy(), "bohr", symmetry=None)
-            mol_feats["grid_weights"] = torch.from_numpy(minimal_grid(mol).weights)
+            mol_feats[Feature.GRID_WEIGHTS] = torch.from_numpy(
+                minimal_grid(mol).weights
+            )
 
             return weight_sum.get_exc(mol_feats)
 
@@ -171,11 +174,11 @@ def test_density_veff(mol_name: str) -> None:
     class TestFunc(ExcFunctionalBase):
         def __init__(self) -> None:
             super().__init__()
-            self.features = ["density", "grid_weights"]
+            self.features = [Feature.DENSITY, Feature.GRID_WEIGHTS]
 
-        def get_exc(self, mol: dict[str, torch.Tensor]) -> torch.Tensor:
+        def get_exc(self, mol: FeatureMap) -> torch.Tensor:
             """This actually calculates the total electron number"""
-            return (mol["density"] @ mol["grid_weights"]).sum()
+            return (mol[Feature.DENSITY] @ mol[Feature.GRID_WEIGHTS]).sum()
 
     def finite_difference_nuc_grad(
         dens_sum: ExcFunctionalBase, mol: gto.Mole, rdm1: torch.Tensor
@@ -203,7 +206,7 @@ def test_density_veff(mol_name: str) -> None:
 
     # calculate analytic result
     veff = veff_and_expl_nuc_grad(
-        exc_test, mol, grid, rdm1, nuc_grad_feats={"density"}
+        exc_test, mol, grid, rdm1, nuc_grad_feats={Feature.DENSITY}
     )[0]
     ana_grad = nuc_grad_from_veff(mol, veff, rdm1)
 
@@ -224,11 +227,11 @@ def test_grad_veff(mol_name: str) -> None:
     class TestFunc(ExcFunctionalBase):
         def __init__(self) -> None:
             super().__init__()
-            self.features = ["grad", "grid_weights"]
+            self.features = [Feature.GRAD, Feature.GRID_WEIGHTS]
 
-        def get_exc(self, mol: dict[str, torch.Tensor]) -> torch.Tensor:
+        def get_exc(self, mol: FeatureMap) -> torch.Tensor:
             return (
-                (mol["grad"] ** 2 @ mol["grid_weights"])
+                (mol[Feature.GRAD] ** 2 @ mol[Feature.GRID_WEIGHTS])
                 @ torch.tensor([1.0, 2.0, 3.0], dtype=torch.float64)
             ).sum()
 
@@ -258,7 +261,9 @@ def test_grad_veff(mol_name: str) -> None:
     num_grad, num_err = finite_difference_nuc_grad(exc_test, mol, rdm1)
 
     # calculate analytic result
-    veff = veff_and_expl_nuc_grad(exc_test, mol, grid, rdm1, nuc_grad_feats={"grad"})[0]
+    veff = veff_and_expl_nuc_grad(
+        exc_test, mol, grid, rdm1, nuc_grad_feats={Feature.GRAD}
+    )[0]
     ana_grad = nuc_grad_from_veff(mol, veff, rdm1)
 
     # This gradient has large-magnitude components whose coarse finite-difference
@@ -286,11 +291,11 @@ def test_kin_veff(mol_name: str) -> None:
     class TestFunc(ExcFunctionalBase):
         def __init__(self) -> None:
             super().__init__()
-            self.features = ["kin", "grid_weights"]
+            self.features = [Feature.KIN, Feature.GRID_WEIGHTS]
 
-        def get_exc(self, mol: dict[str, torch.Tensor]) -> torch.Tensor:
+        def get_exc(self, mol: FeatureMap) -> torch.Tensor:
             """This actually calculates the total kinetic energy number"""
-            return (mol["kin"] @ mol["grid_weights"]).sum()
+            return (mol[Feature.KIN] @ mol[Feature.GRID_WEIGHTS]).sum()
 
     def finite_difference_nuc_grad(
         kin_func: ExcFunctionalBase, mol: gto.Mole, rdm1: torch.Tensor
@@ -318,7 +323,9 @@ def test_kin_veff(mol_name: str) -> None:
     num_grad, num_err = finite_difference_nuc_grad(exc_test, mol, rdm1)
 
     # calculate analytic result
-    veff = veff_and_expl_nuc_grad(exc_test, mol, grid, rdm1, nuc_grad_feats={"kin"})[0]
+    veff = veff_and_expl_nuc_grad(
+        exc_test, mol, grid, rdm1, nuc_grad_feats={Feature.KIN}
+    )[0]
     ana_grad = nuc_grad_from_veff(mol, veff, rdm1)
 
     # Like test_grad_veff, the kinetic-energy gradient has large-magnitude
@@ -475,10 +482,10 @@ def test_atomic_grid_weights_gradient(mol_name: str) -> None:
     class TestFunc(ExcFunctionalBase):
         def __init__(self) -> None:
             super().__init__()
-            self.features = ["atomic_grid_weights"]
+            self.features = [Feature.ATOMIC_GRID_WEIGHTS]
 
-        def get_exc(self, mol: dict[str, torch.Tensor]) -> torch.Tensor:
-            return mol["atomic_grid_weights"].sum()
+        def get_exc(self, mol: FeatureMap) -> torch.Tensor:
+            return mol[Feature.ATOMIC_GRID_WEIGHTS].sum()
 
     mol = get_mol(mol_name)
     grid, rdm1 = get_grid_and_rdm1(mol)
@@ -504,17 +511,17 @@ def test_atomic_grid_features_passthrough(mol_name: str) -> None:
         def __init__(self) -> None:
             super().__init__()
             self.features = [
-                "density",
-                "grid_weights",
-                "atomic_grid_weights",
-                "atomic_grid_sizes",
-                "atomic_grid_size_bound_shape",
+                Feature.DENSITY,
+                Feature.GRID_WEIGHTS,
+                Feature.ATOMIC_GRID_WEIGHTS,
+                Feature.ATOMIC_GRID_SIZES,
+                Feature.ATOMIC_GRID_SIZE_BOUND_SHAPE,
             ]
 
-        def get_exc(self, mol: dict[str, torch.Tensor]) -> torch.Tensor:
+        def get_exc(self, mol: FeatureMap) -> torch.Tensor:
             # Use density and grid_weights (differentiable) plus atomic_grid_weights (other_feat)
-            n_electrons = (mol["density"] @ mol["grid_weights"]).sum()
-            agw_sum = mol["atomic_grid_weights"].sum()
+            n_electrons = (mol[Feature.DENSITY] @ mol[Feature.GRID_WEIGHTS]).sum()
+            agw_sum = mol[Feature.ATOMIC_GRID_WEIGHTS].sum()
             return n_electrons + agw_sum
 
     mol = get_mol(mol_name)
@@ -540,15 +547,15 @@ def test_explicit_nuc_grad_feats_with_integer_features(mol_name: str) -> None:
         def __init__(self) -> None:
             super().__init__()
             self.features = [
-                "density",
-                "grid_weights",
-                "atomic_grid_weights",
-                "atomic_grid_sizes",
-                "atomic_grid_size_bound_shape",
+                Feature.DENSITY,
+                Feature.GRID_WEIGHTS,
+                Feature.ATOMIC_GRID_WEIGHTS,
+                Feature.ATOMIC_GRID_SIZES,
+                Feature.ATOMIC_GRID_SIZE_BOUND_SHAPE,
             ]
 
-        def get_exc(self, mol: dict[str, torch.Tensor]) -> torch.Tensor:
-            return (mol["density"] @ mol["grid_weights"]).sum()
+        def get_exc(self, mol: FeatureMap) -> torch.Tensor:
+            return (mol[Feature.DENSITY] @ mol[Feature.GRID_WEIGHTS]).sum()
 
     mol = get_mol(mol_name)
     grid, rdm1 = get_grid_and_rdm1(mol)
@@ -556,7 +563,7 @@ def test_explicit_nuc_grad_feats_with_integer_features(mol_name: str) -> None:
 
     exc_test = TestFunc()
     # Explicitly pass all features including integer ones — should auto-discard them
-    veff, nuc_grad = veff_and_expl_nuc_grad(
+    _vexc, nuc_grad = veff_and_expl_nuc_grad(
         exc_test, mol, grid, rdm1, nuc_grad_feats=set(exc_test.features)
     )
     assert nuc_grad.shape == (mol.natm, 3)


### PR DESCRIPTION
## Summary

- Add string-compatible `Feature` identifiers and the `FeatureMap` type.
- Add `FeatureSpec` to derive AO derivative, meta-GGA, and atomic-layout requirements.
- Add immutable `EvaluationPolicy` settings shared by later evaluation paths.
- Migrate functional, PySCF, CPU/GPU gradient, example, and test code to the typed feature API.
- Fold in supporting repository cleanup:
  - run mypy through pre-commit
  - add notebook cleanup checks
  - clean existing documentation notebooks
  - update development dependency constraints

This PR establishes the common feature and evaluation contracts used by the following pullback and AO-screening PRs. It does not implement AO screening.
