### PR TITLE
disable env caching

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -41,7 +41,8 @@ jobs:
       with:
         environment-file: environment-cpu.yml
         environment-name: skala-dev
-        cache-environment: true
+        # Recreate native environments per runner; restored environments caused SIGILL failures.
+        cache-environment: false
         cache-downloads: true
 
     - name: Install Skala
@@ -81,7 +82,8 @@ jobs:
       with:
         environment-file: skala/examples/${{ matrix.example }}/gauxc_integration/environment-${{ matrix.toolchain }}.yml
         environment-name: gauxc-dev
-        cache-environment: true
+        # Recreate native environments per runner; restored environments caused SIGILL failures.
+        cache-environment: false
         cache-downloads: true
 
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -170,7 +172,8 @@ jobs:
       with:
         environment-file: examples/fortran/ftorch_integration/environment.yml
         environment-name: ftorch-dev
-        cache-environment: true
+        # Recreate native environments per runner; restored environments caused SIGILL failures.
+        cache-environment: false
         cache-downloads: true
 
     - name: Configure project


### PR DESCRIPTION
## Summary

Disable full micromamba environment caching for the `pt-features`, `gauxc`, and
`ftorch` example jobs. Package download caching remains enabled.

## Motivation

The `pt-features` job intermittently terminated with exit code 132 (`SIGILL`)
when restoring a cached micromamba environment. Running the same job with a
freshly created environment succeeded.

The environment cache key includes the Conda platform and environment file
contents, but not CPU capabilities such as Conda's `__archspec` or the exact
resolved package set. A native environment created on one hosted runner may
therefore be restored on another runner with different CPU characteristics or
retain otherwise stale native state.

The remaining example jobs also compile and execute native code, so the same
policy is applied consistently to all three jobs.

## Changes

- Set `cache-environment: false` for `pt-features`, `gauxc`, and `ftorch`.
- Keep `cache-downloads: true` to retain package download reuse.
- Document why full environment caching is disabled.