### PR TITLE
Add ARM CI and prevent checkpoint leaks

### DIFF
--- a/.github/actions/cpu-diagnostics/action.yml
+++ b/.github/actions/cpu-diagnostics/action.yml
@@ -1,0 +1,15 @@
+name: CPU diagnostics
+description: "Print operating-system, processor, and CPU-feature information."
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        uname -a
+        if [[ -r /proc/cpuinfo ]]; then cat /proc/cpuinfo; fi
+        if command -v lscpu >/dev/null 2>&1; then lscpu; fi
+        if [[ "$(uname -s)" == "Darwin" ]]; then
+          system_profiler SPHardwareDataType
+          sysctl -a | grep -E '^(machdep\.cpu\.(brand_string|features|leaf7_features)|hw\.(machine|model|ncpu|physicalcpu|logicalcpu)):' || true
+        fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         environment-file: environment-cpu.yml
         environment-name: skala
-        cache-environment: true
+        cache-environment: false
         cache-downloads: true
 
     - name: Install package in development mode
@@ -43,10 +43,6 @@ jobs:
         runner: [ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         pyscf-version: ["2.9", "2.11"]
-        exclude: # Skip PySCF 2.11 on Python 3.12 because of multithreading crash when calling getints2c
-          - runner: ubuntu-latest
-            python-version: "3.12"
-            pyscf-version: "2.11"
         include:
           - runner: ubuntu-24.04-arm
             python-version: "3.12"
@@ -55,7 +51,7 @@ jobs:
             python-version: "3.12"
             pyscf-version: "2.11"
 
-    name: "Python=${{ matrix.python-version }} & PySCF=${{ matrix.pyscf-version }} @ {{ matrix.runner }}"
+    name: "Python=${{ matrix.python-version }} & PySCF=${{ matrix.pyscf-version }} @ ${{ matrix.runner }}"
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -64,7 +60,7 @@ jobs:
       with:
         environment-file: environment-cpu.yml
         environment-name: skala
-        cache-environment: true
+        cache-environment: false
         cache-downloads: true
         create-args: >-
           python=${{ matrix.python-version }}
@@ -86,6 +82,10 @@ jobs:
         tests/
       shell: micromamba-shell {0}
 
+    - name: Print CPU diagnostics on failure
+      if: ${{ failure() }}
+      uses: ./.github/actions/cpu-diagnostics
+
   gpu-test:
     runs-on: microsoft-skala-gpu-pool
     needs:
@@ -98,7 +98,7 @@ jobs:
       with:
         environment-file: environment-gpu.yml
         environment-name: skala-gpu
-        cache-environment: true
+        cache-environment: false
         cache-downloads: true
 
     - name: Install package in development mode

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,3 +111,45 @@ jobs:
         tests/test_gpu4pyscf_classes.py
         tests/test_gpu4pyscf_gradients.py
       shell: micromamba-shell {0}
+
+  arm-test:
+    name: "ARM tests (${{ matrix.runner }})"
+    runs-on: ${{ matrix.runner }}
+    env:
+      OMP_NUM_THREADS: 4
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-24.04-arm, macos-14]
+    steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+    - name: Print CPU diagnostics
+      uses: ./.github/actions/cpu-diagnostics
+
+    - name: Setup micromamba
+      uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39 # v3
+      with:
+        environment-file: environment-cpu.yml
+        environment-name: skala
+        # Recreate native environments per runner to avoid restoring CPU-specific binaries.
+        cache-environment: false
+        cache-downloads: true
+        create-args: >-
+          python=3.12
+          pyscf=2.11
+
+    - name: Install package in development mode
+      run: pip install -e . --no-deps
+      shell: micromamba-shell {0}
+
+    - name: Run tests with coverage
+      run: >-
+        pytest
+        -v
+        --doctest-modules
+        --cov=skala --cov-report=xml --cov-report=term-missing --cov-report=html
+        --durations=50 --durations-min=1.0
+        --pyargs skala
+        tests/
+      shell: micromamba-shell {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,19 +34,28 @@ jobs:
       shell: micromamba-shell {0}
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs:
       - lint
     strategy:
       fail-fast: false
       matrix:
+        runner: [ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         pyscf-version: ["2.9", "2.11"]
         exclude: # Skip PySCF 2.11 on Python 3.12 because of multithreading crash when calling getints2c
-          - python-version: "3.12"
+          - runner: ubuntu-latest
+            python-version: "3.12"
+            pyscf-version: "2.11"
+        include:
+          - runner: ubuntu-24.04-arm
+            python-version: "3.12"
+            pyscf-version: "2.11"
+          - runner: macos-14
+            python-version: "3.12"
             pyscf-version: "2.11"
 
-    name: "Python=${{ matrix.python-version }} & PySCF=${{ matrix.pyscf-version }}"
+    name: "Python=${{ matrix.python-version }} & PySCF=${{ matrix.pyscf-version }} @ {{ matrix.runner }}"
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -110,46 +119,4 @@ jobs:
         src/skala/gpu4pyscf/
         tests/test_gpu4pyscf_classes.py
         tests/test_gpu4pyscf_gradients.py
-      shell: micromamba-shell {0}
-
-  arm-test:
-    name: "ARM tests (${{ matrix.runner }})"
-    runs-on: ${{ matrix.runner }}
-    env:
-      OMP_NUM_THREADS: 4
-    strategy:
-      fail-fast: false
-      matrix:
-        runner: [ubuntu-24.04-arm, macos-14]
-    steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-    - name: Print CPU diagnostics
-      uses: ./.github/actions/cpu-diagnostics
-
-    - name: Setup micromamba
-      uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39 # v3
-      with:
-        environment-file: environment-cpu.yml
-        environment-name: skala
-        # Recreate native environments per runner to avoid restoring CPU-specific binaries.
-        cache-environment: false
-        cache-downloads: true
-        create-args: >-
-          python=3.12
-          pyscf=2.11
-
-    - name: Install package in development mode
-      run: pip install -e . --no-deps
-      shell: micromamba-shell {0}
-
-    - name: Run tests with coverage
-      run: >-
-        pytest
-        -v
-        --doctest-modules
-        --cov=skala --cov-report=xml --cov-report=term-missing --cov-report=html
-        --durations=50 --durations-min=1.0
-        --pyargs skala
-        tests/
       shell: micromamba-shell {0}

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 
-"""Shared test fixtures."""
+"""Repository-wide pytest configuration."""
 
 import functools
 from collections.abc import Callable, Iterator
@@ -25,8 +25,9 @@ def mute_pyscf_temporary_checkpoints() -> Iterator[None]:
 
     Preventing the unused files through PySCF's ``MUTE_CHKFILE`` switch avoids
     the resource lifetime problem instead of filtering platform-specific warning
-    messages. The previous setting is restored after the session, and production
-    behavior is unchanged.
+    messages. This repository-level fixture covers package doctests as well as
+    tests under ``tests/``. The previous setting is restored after the session,
+    and production behavior is unchanged.
     """
     previous = hf.MUTE_CHKFILE
     hf.MUTE_CHKFILE = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,16 +102,6 @@ filterwarnings = [
     'ignore:`torch\.jit\.script` is deprecated\. Please switch to `torch\.compile` or `torch\.export`\.:DeprecationWarning',
     'ignore:`torch\.jit\.save` is deprecated\. Please switch to `torch\.export`\.:DeprecationWarning',
     'ignore:`torch\.jit\.save` is not supported in Python 3\.14+ and may break\. Please switch to `torch\.export`\.:DeprecationWarning',
-    # PySCF's `SCF.__init__` (pyscf/scf/hf.py, currently line 1733) creates
-    # `self._chkfile = tempfile.NamedTemporaryFile(...)` as its checkpoint file
-    # and relies on finalization to close it, which emits ResourceWarning during
-    # GC. The warning is emitted by CPython's I/O layer (not from the pyscf
-    # module), so we match on the message. Traced via PYTHONTRACEMALLOC.
-    "ignore:unclosed file <_io\\.FileIO name='/tmp/tmp.*' mode='rb\\+' closefd=True>:ResourceWarning",
-    # On recent pytest versions the same leaked tempfile surfaces during GC at
-    # session teardown via the unraisable-exception hook, which re-emits it as
-    # `pytest.PytestUnraisableExceptionWarning`. Filter that wrapper too.
-    "ignore:Exception ignored in. <_io\\.FileIO name='/tmp/tmp.*' mode='rb\\+' closefd=True>:pytest.PytestUnraisableExceptionWarning",
     # From gpu4pyscf if cutensor is not available
     'ignore:using cupy as the tensor contraction engine\.:UserWarning',
     # Deprecation warning in huggingface_hub package

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,11 +3,37 @@
 """Shared test fixtures."""
 
 import functools
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 
 import pytest
+from pyscf.scf import hf
 
 from skala.functional import ExcFunctionalBase, load_functional
+
+
+@pytest.fixture(scope="session", autouse=True)
+def mute_pyscf_temporary_checkpoints() -> Iterator[None]:
+    """Disable implicit PySCF checkpoint files for the test session.
+
+    PySCF opens a ``NamedTemporaryFile`` whenever it constructs an SCF object,
+    even when a test never requests checkpointing. Some transformed SCF objects
+    participate in reference cycles, so their temporary files can remain open
+    until cyclic garbage collection. Python then emits ``ResourceWarning``, and
+    pytest 9 re-emits it as ``PytestUnraisableExceptionWarning``. Because this
+    project treats warnings as errors, whichever test triggers collection can
+    fail even if a different test created the file.
+
+    Preventing the unused files through PySCF's ``MUTE_CHKFILE`` switch avoids
+    the resource lifetime problem instead of filtering platform-specific warning
+    messages. The previous setting is restored after the session, and production
+    behavior is unchanged.
+    """
+    previous = hf.MUTE_CHKFILE
+    hf.MUTE_CHKFILE = True
+    try:
+        yield
+    finally:
+        hf.MUTE_CHKFILE = previous
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
# Summary

- Add an ARM CI matrix covering `ubuntu-24.04-arm` and `macos-14`.
- Run ARM tests with Python 3.12, PySCF 2.11, and `OMP_NUM_THREADS=4`.
- Add a reusable CPU diagnostics action for architecture-specific CI failures.
- Prevent unused PySCF checkpoint files from being created during tests.
- Remove platform-specific warning suppressions for leaked checkpoint files.

## Background

PySCF creates a `NamedTemporaryFile` for every SCF object, even when checkpointing is not requested. Some transformed SCF objects participate in reference cycles, which can delay file cleanup until cyclic garbage collection.

Python then emits a `ResourceWarning`, which pytest 9 re-emits as a `PytestUnraisableExceptionWarning`. Because warnings are treated as errors, an unrelated test can fail when it happens to trigger garbage collection. The existing suppression only matched Linux `/tmp` paths and did not cover macOS paths under `/var/folders`.

The new session-scoped fixture enables PySCF's `MUTE_CHKFILE` setting during tests and restores its previous value afterward. This prevents the unused files from being opened instead of suppressing their cleanup warnings. Production behavior is unchanged.