### PR TITLE
Update gpu4pyscf to 1.8.1

### DIFF
--- a/.github/workflows/pypi/skala-cuda.toml
+++ b/.github/workflows/pypi/skala-cuda.toml
@@ -17,7 +17,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "skala==@VERSION@",
-    "gpu4pyscf-cuda@CUDA@ >=1.6,<1.8,!=1.7.1,!=1.7.2",
+    "gpu4pyscf-cuda@CUDA@ >=1.8,<1.9",
 ]
 urls.repository = "https://github.com/microsoft/skala"
 urls.documentation = "https://microsoft.github.io/skala"

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -75,8 +75,8 @@ If you prefer to install Skala from the source code, you can clone the repositor
 where ``environment-cpu.yml`` can be replaced with ``environment-gpu.yml`` for
 GPU support via `GPU4PySCF <https://github.com/pyscf/gpu4pyscf>`__. The GPU
 environment pins ``cuda-toolkit 12``, ``cuda-version 12``, ``cutensor``, and
-installs ``gpu4pyscf-cuda12x >=1.6,<1.8,!=1.7.1,!=1.7.2`` from PyPI as part of the environment file —
-no separate install step is required:
+installs ``gpu4pyscf-cuda12x >=1.8,<1.9`` from PyPI as part of the environment
+file — no separate install step is required:
 
 .. code-block:: bash
 

--- a/docs/pyscf/gpu4pyscf.rst
+++ b/docs/pyscf/gpu4pyscf.rst
@@ -24,8 +24,8 @@ Installation
 
 The recommended way to set up a GPU environment is the provided
 ``environment-gpu.yml``, which pins ``pytorch-gpu``, ``cuda-toolkit 12``,
-``cuda-version 12``, ``cutensor``, and installs ``gpu4pyscf-cuda12x 1.5`` from
-PyPI as part of the environment file:
+``cuda-version 12``, ``cutensor``, and installs
+``gpu4pyscf-cuda12x >=1.8,<1.9`` from PyPI as part of the environment file:
 
 .. code-block:: bash
 

--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -27,4 +27,4 @@ dependencies:
   - mypy >=2
   - pip:
     - huggingface_hub
-    - gpu4pyscf-cuda12x >=1.6,<1.8,!=1.7.1,!=1.7.2
+    - gpu4pyscf-cuda12x >=1.8,<1.9

--- a/src/skala/gpu4pyscf/dft.py
+++ b/src/skala/gpu4pyscf/dft.py
@@ -133,7 +133,7 @@ class SkalaRKS(dft.rks.RKS):  # type: ignore[misc]
         self,
         auxbasis: str | None = None,
         with_df: bool | None = None,
-        only_dfj: bool | None = True,
+        only_dfj: bool | None = False,
     ) -> "SkalaRKS":
         if pyscf_version_newer_than_2_10() and auxbasis is None:
             warnings.warn(
@@ -216,7 +216,7 @@ class SkalaUKS(dft.uks.UKS):  # type: ignore[misc]
         self,
         auxbasis: str | None = None,
         with_df: bool | None = None,
-        only_dfj: bool | None = True,
+        only_dfj: bool | None = False,
     ) -> "SkalaUKS":
         if pyscf_version_newer_than_2_10() and auxbasis is None:
             warnings.warn(

--- a/src/skala/gpu4pyscf/gradients.py
+++ b/src/skala/gpu4pyscf/gradients.py
@@ -3,7 +3,6 @@
 """Modification of PySCF nuclear gradient object to work with Skala functional."""
 
 import logging
-from typing import Any
 
 import cupy as cp
 import numpy as np
@@ -358,7 +357,7 @@ class SkalaRKSGradient(RHFGradient):  # type: ignore[misc]
         nuc_g += disp_g
         return nuc_g
 
-    def extra_force(self, atom_id: int, envs: dict[str, Any]) -> int:
+    def extra_force(self, atom_id: int | None = None) -> int:
         return 0
 
     def reset(self, mol: gto.Mole | None = None) -> "SkalaRKSGradient":
@@ -456,7 +455,7 @@ class SkalaUKSGradient(UHFGradient):  # type: ignore[misc]
         nuc_g += disp_g
         return nuc_g
 
-    def extra_force(self, atom_id: int, envs: dict[str, Any]) -> int:
+    def extra_force(self, atom_id: int | None = None) -> int:
         return 0
 
     def reset(self, mol: gto.Mole | None = None) -> "SkalaUKSGradient":

--- a/src/skala/gpu4pyscf/grids.py
+++ b/src/skala/gpu4pyscf/grids.py
@@ -11,9 +11,19 @@ LOG = getLogger(__name__)
 
 class UnsortableGrids(gen_grid.Grids):  # type: ignore
     def build(
-        self, mol: gto.Mole | None = None, with_non0tab: bool = False, **kwargs: Any
+        self,
+        mol: gto.Mole | None = None,
+        with_non0tab: bool = False,
+        sort_grids: bool = True,
+        sort_grids_of_each_atom: bool = False,
+        **kwargs: Any,
     ) -> "UnsortableGrids":
-        sort_grids = kwargs.pop("sort_grids", None)
-        if sort_grids:
+        if sort_grids or sort_grids_of_each_atom:
             LOG.debug("sorted grids not supported, forcing unsorted grids")
-        return super().build(mol, with_non0tab, sort_grids=False, **kwargs)
+        return super().build(
+            mol,
+            with_non0tab,
+            sort_grids=False,
+            sort_grids_of_each_atom=False,
+            **kwargs,
+        )

--- a/tests/test_gpu4pyscf_classes.py
+++ b/tests/test_gpu4pyscf_classes.py
@@ -99,3 +99,26 @@ def test_skala_class(
     assert ks.with_dftd3 is not None if with_dftd3 else ks.with_dftd3 is None
     if ks._needs_unsorted:
         assert isinstance(ks.grids, UnsortableGrids)
+
+
+def test_unsortable_grids_disable_all_gpu4pyscf_sorting(
+    mol: gto.Mole, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    build_options: dict[str, bool] = {}
+
+    def build(
+        self: object,
+        mol: gto.Mole | None = None,
+        with_non0tab: bool = False,
+        **kwargs: bool,
+    ) -> object:
+        build_options.update(kwargs)
+        return self
+
+    monkeypatch.setattr("gpu4pyscf.dft.gen_grid.Grids.build", build)
+
+    grids = UnsortableGrids(mol)
+    grids.build(sort_grids=True, sort_grids_of_each_atom=True)
+
+    assert build_options["sort_grids"] is False
+    assert build_options["sort_grids_of_each_atom"] is False


### PR DESCRIPTION
This latest release solves an out-of-memory problem with density fitting that allows us to run Skala on larger molecules.