### PR TITLE
Shorten docs menu labels

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,7 +25,7 @@ The model is trained on a large dataset of highly accurate total atomization ene
    SCF settings <pyscf/scf_settings>
    ASE <ase>
    FTorch <ftorch>
-   GAUXC <gauxc/index>
+   GauXC <gauxc/index>
 
 .. toctree::
    :maxdepth: 1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,7 +24,7 @@ The model is trained on a large dataset of highly accurate total atomization ene
    GPU4PySCF <pyscf/gpu4pyscf>
    SCF settings <pyscf/scf_settings>
    ASE <ase>
-   FTorch <ftorch>
+   Fortran (FTorch) <ftorch>
    GauXC <gauxc/index>
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,13 +19,13 @@ The model is trained on a large dataset of highly accurate total atomization ene
    :caption: User guide
    :hidden:
 
-   installation
-   pyscf/singlepoint
-   pyscf/gpu4pyscf
-   pyscf/scf_settings
-   ase
-   ftorch
-   gauxc/index
+   Installation <installation>
+   PySCF Single-point calculations <pyscf/singlepoint>
+   GPU4PySCF <pyscf/gpu4pyscf>
+   SCF settings <pyscf/scf_settings>
+   ASE <ase>
+   FTorch <ftorch>
+   GAUXC <gauxc/index>
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
This makes it easier to navigate the docs (skipping things like 'Using Skala with' throughout.