### PR TITLE
Fix cuda dependency conflicts 

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ pip install skala-cuda12x
 The `skala-cuda11x` and `skala-cuda13x` packages are also available for CUDA 11 and 13, respectively.
 
 The recommended path is the provided [`environment-gpu.yml`](environment-gpu.yml),
-which pins `pytorch-gpu`, `cuda-toolkit` 12, `cutensor`, and installs `gpu4pyscf-cuda12x` from PyPI:
+which pins `pytorch-gpu`, CUDA 12, `cuda-nvrtc` for CuPy kernel compilation,
+and `cutensor`, and installs `gpu4pyscf-cuda12x` from PyPI:
 
 ```bash
 mamba env create -n skala -f environment-gpu.yml
@@ -100,7 +101,7 @@ proceeds without a device:
 CONDA_OVERRIDE_CUDA=12.0 mamba env create -n skala -f environment-gpu.yml
 ```
 
-For CUDA 11 or 13, adjust `cuda-toolkit`, `cuda-version`, and the
+For CUDA 11 or 13, adjust `cuda-version`, `cuda-nvrtc`, and the
 `gpu4pyscf-cuda{11,13}x` pin in `environment-gpu.yml` accordingly. Check your
 driver's maximum supported CUDA version with `nvidia-smi`.
 

--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ pip install skala-cuda12x
 The `skala-cuda11x` and `skala-cuda13x` packages are also available for CUDA 11 and 13, respectively.
 
 The recommended path is the provided [`environment-gpu.yml`](environment-gpu.yml),
-which pins `pytorch-gpu`, CUDA 12, `cuda-nvrtc` for CuPy kernel compilation,
-and `cutensor`, and installs `gpu4pyscf-cuda12x` from PyPI:
+which pins `pytorch-gpu`, CUDA 12, `cuda-nvrtc` and matching `cuda-cudart-dev`
+headers for CuPy kernel compilation, and `cutensor`, and installs
+`gpu4pyscf-cuda12x` from PyPI:
 
 ```bash
 mamba env create -n skala -f environment-gpu.yml
@@ -101,9 +102,9 @@ proceeds without a device:
 CONDA_OVERRIDE_CUDA=12.0 mamba env create -n skala -f environment-gpu.yml
 ```
 
-For CUDA 11 or 13, adjust `cuda-version`, `cuda-nvrtc`, and the
-`gpu4pyscf-cuda{11,13}x` pin in `environment-gpu.yml` accordingly. Check your
-driver's maximum supported CUDA version with `nvidia-smi`.
+For CUDA 11 or 13, adjust `cuda-version`, `cuda-nvrtc`, `cuda-cudart-dev`, and
+the `gpu4pyscf-cuda{11,13}x` pin in `environment-gpu.yml` accordingly. Check
+your driver's maximum supported CUDA version with `nvidia-smi`.
 
 Run an SCF calculation with Skala for a hydrogen molecule on GPU:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -74,9 +74,10 @@ If you prefer to install Skala from the source code, you can clone the repositor
 
 where ``environment-cpu.yml`` can be replaced with ``environment-gpu.yml`` for
 GPU support via `GPU4PySCF <https://github.com/pyscf/gpu4pyscf>`__. The GPU
-environment pins ``cuda-toolkit 12``, ``cuda-version 12``, ``cutensor``, and
-installs ``gpu4pyscf-cuda12x >=1.8,<1.9`` from PyPI as part of the environment
-file — no separate install step is required:
+environment pins ``pytorch-gpu``, ``cuda-version 12``, ``cuda-nvrtc`` for CuPy
+kernel compilation, and ``cutensor``. It installs
+``gpu4pyscf-cuda12x >=1.8,<1.9`` from PyPI as part of the environment file — no
+separate install step is required:
 
 .. code-block:: bash
 
@@ -92,7 +93,7 @@ solver proceeds without a device:
 
    CONDA_OVERRIDE_CUDA=12.0 mamba env create -n skala -f environment-gpu.yml
 
-For CUDA 11 or 13, adjust ``cuda-toolkit``, ``cuda-version``, and the
+For CUDA 11 or 13, adjust ``cuda-version``, ``cuda-nvrtc``, and the
 ``gpu4pyscf-cuda{11,13}x`` pin in ``environment-gpu.yml`` accordingly. Check
 your driver's maximum supported CUDA version with ``nvidia-smi``.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -75,7 +75,7 @@ If you prefer to install Skala from the source code, you can clone the repositor
 where ``environment-cpu.yml`` can be replaced with ``environment-gpu.yml`` for
 GPU support via `GPU4PySCF <https://github.com/pyscf/gpu4pyscf>`__. The GPU
 environment pins ``pytorch-gpu``, ``cuda-version 12``, ``cuda-nvrtc`` for CuPy
-kernel compilation, and ``cutensor``. It installs
+kernel compilation, matching ``cuda-cudart-dev`` headers, and ``cutensor``. It installs
 ``gpu4pyscf-cuda12x >=1.8,<1.9`` from PyPI as part of the environment file — no
 separate install step is required:
 
@@ -93,9 +93,10 @@ solver proceeds without a device:
 
    CONDA_OVERRIDE_CUDA=12.0 mamba env create -n skala -f environment-gpu.yml
 
-For CUDA 11 or 13, adjust ``cuda-version``, ``cuda-nvrtc``, and the
-``gpu4pyscf-cuda{11,13}x`` pin in ``environment-gpu.yml`` accordingly. Check
-your driver's maximum supported CUDA version with ``nvidia-smi``.
+For CUDA 11 or 13, adjust ``cuda-version``, ``cuda-nvrtc``,
+``cuda-cudart-dev``, and the ``gpu4pyscf-cuda{11,13}x`` pin in
+``environment-gpu.yml`` accordingly. Check your driver's maximum supported
+CUDA version with ``nvidia-smi``.
 
 To install the development dependencies, you can run:
 

--- a/docs/pyscf/gpu4pyscf.rst
+++ b/docs/pyscf/gpu4pyscf.rst
@@ -24,8 +24,9 @@ Installation
 
 The recommended way to set up a GPU environment is the provided
 ``environment-gpu.yml``, which pins ``pytorch-gpu``, ``cuda-version 12``,
-``cuda-nvrtc`` for CuPy kernel compilation, and ``cutensor``. It installs
-``gpu4pyscf-cuda12x >=1.8,<1.9`` from PyPI as part of the environment file:
+``cuda-nvrtc`` and matching ``cuda-cudart-dev`` headers for CuPy kernel
+compilation, and ``cutensor``. It installs ``gpu4pyscf-cuda12x >=1.8,<1.9``
+from PyPI as part of the environment file:
 
 .. code-block:: bash
 
@@ -33,8 +34,9 @@ The recommended way to set up a GPU environment is the provided
    mamba activate skala
    pip install skala
 
-For CUDA 11 or 13, adjust ``cuda-version``, ``cuda-nvrtc``, and the
-``gpu4pyscf-cuda{11,13}x`` pin in ``environment-gpu.yml`` accordingly.
+For CUDA 11 or 13, adjust ``cuda-version``, ``cuda-nvrtc``,
+``cuda-cudart-dev``, and the ``gpu4pyscf-cuda{11,13}x`` pin in
+``environment-gpu.yml`` accordingly.
 
 See the :doc:`installation guide </installation>` for more details, including
 how to install from conda-forge or inside a container without a GPU attached.

--- a/docs/pyscf/gpu4pyscf.rst
+++ b/docs/pyscf/gpu4pyscf.rst
@@ -23,8 +23,8 @@ Installation
 ------------
 
 The recommended way to set up a GPU environment is the provided
-``environment-gpu.yml``, which pins ``pytorch-gpu``, ``cuda-toolkit 12``,
-``cuda-version 12``, ``cutensor``, and installs
+``environment-gpu.yml``, which pins ``pytorch-gpu``, ``cuda-version 12``,
+``cuda-nvrtc`` for CuPy kernel compilation, and ``cutensor``. It installs
 ``gpu4pyscf-cuda12x >=1.8,<1.9`` from PyPI as part of the environment file:
 
 .. code-block:: bash
@@ -33,7 +33,7 @@ The recommended way to set up a GPU environment is the provided
    mamba activate skala
    pip install skala
 
-For CUDA 11 or 13, adjust ``cuda-toolkit``, ``cuda-version``, and the
+For CUDA 11 or 13, adjust ``cuda-version``, ``cuda-nvrtc``, and the
 ``gpu4pyscf-cuda{11,13}x`` pin in ``environment-gpu.yml`` accordingly.
 
 See the :doc:`installation guide </installation>` for more details, including

--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -11,11 +11,10 @@ dependencies:
   - opt_einsum_fx
   - pyscf >=2.8,<2.14
   - python
-  - pytorch-gpu
-  - cuda-toolkit >=12,<13
-  - cuda-version >=12,<13
-  - cuda-nvcc >=12,<13
-  - cutensor >=2
+  - pytorch-gpu  # CUDA-enabled PyTorch for Skala model inference
+  - cuda-version >=12,<13  # Constrains conda CUDA packages to CUDA 12
+  - cuda-nvrtc >=12,<13  # Runtime compiler used by CuPy for GPU kernels
+  - cutensor >=2  # Tensor-contraction backend used by GPU4PySCF
   # Testing and development dependencies
   - pre-commit
   - pytest
@@ -27,4 +26,4 @@ dependencies:
   - mypy >=2
   - pip:
     - huggingface_hub
-    - gpu4pyscf-cuda12x >=1.8,<1.9
+    - gpu4pyscf-cuda12x >=1.8,<1.9  # GPU-accelerated PySCF backend used by Skala

--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -14,6 +14,7 @@ dependencies:
   - pytorch-gpu  # CUDA-enabled PyTorch for Skala model inference
   - cuda-version >=12,<13  # Constrains conda CUDA packages to CUDA 12
   - cuda-nvrtc >=12,<13  # Runtime compiler used by CuPy for GPU kernels
+  - cuda-cudart-dev >=12,<13  # Matching CUDA headers for CuPy kernel compilation
   - cutensor >=2  # Tensor-contraction backend used by GPU4PySCF
   # Testing and development dependencies
   - pre-commit


### PR DESCRIPTION
Somehow https://github.com/microsoft/skala/pull/116 broke main, by making the gpu conda environment not resolvable. 

This fixes it as we do not need the whole cuda toolkit.