### PR TITLE
Restructure pipelines

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -3,20 +3,14 @@ name: GauXC examples
 on:
   push:
     branches: [main]
-    paths:
-      - '.github/actions/cpu-diagnostics/action.yml'
+    paths: &gauxc-paths
       - '.github/workflows/examples.yml'
       - 'examples/c/gauxc_integration/**'
       - 'examples/cpp/gauxc_integration/**'
       - 'examples/fortran/gauxc_integration/**'
   pull_request:
     branches: [main]
-    paths:
-      - '.github/actions/cpu-diagnostics/action.yml'
-      - '.github/workflows/examples.yml'
-      - 'examples/c/gauxc_integration/**'
-      - 'examples/cpp/gauxc_integration/**'
-      - 'examples/fortran/gauxc_integration/**'
+    paths: *gauxc-paths
 
 permissions:
   contents: read

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,10 +1,22 @@
-name: Examples
+name: GauXC examples
 
 on:
   push:
-    branches: [ main, dev ]
+    branches: [main]
+    paths:
+      - '.github/actions/cpu-diagnostics/action.yml'
+      - '.github/workflows/examples.yml'
+      - 'examples/c/gauxc_integration/**'
+      - 'examples/cpp/gauxc_integration/**'
+      - 'examples/fortran/gauxc_integration/**'
   pull_request:
-    branches: [ main, dev ]
+    branches: [main]
+    paths:
+      - '.github/actions/cpu-diagnostics/action.yml'
+      - '.github/workflows/examples.yml'
+      - 'examples/c/gauxc_integration/**'
+      - 'examples/cpp/gauxc_integration/**'
+      - 'examples/fortran/gauxc_integration/**'
 
 permissions:
   contents: read
@@ -37,39 +49,6 @@ jobs:
       with:
         name: skala-checkpoint
         path: skala-1.1-rev1.fun
-
-  pt-features:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-    - name: Print CPU diagnostics
-      uses: ./.github/actions/cpu-diagnostics
-
-    - name: Setup micromamba
-      uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39 # v3
-      with:
-        environment-file: environment-cpu.yml
-        environment-name: skala-dev
-        # Recreate native environments per runner; restored environments caused SIGILL failures.
-        cache-environment: false
-        cache-downloads: true
-
-    - name: Install Skala
-      run: pip install -e .
-      shell: micromamba-shell {0}
-
-    - name: Generate features
-      run: >-
-        python examples/cpp/cpp_integration/prepare_inputs.py
-        --output-dir features
-      shell: micromamba-shell {0}
-
-    - name: Upload features
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-      with:
-        name: pt-features
-        path: features
 
   gauxc:
     needs:
@@ -170,61 +149,4 @@ jobs:
          Skala
          ./gauxc/tests/ref_data/onedft_he_def2qzvp_tpss_uks.hdf5
          --model ./skala-1.1-rev1.fun
-      shell: micromamba-shell {0}
-
-  ftorch:
-    runs-on: ubuntu-latest
-    needs:
-      - pt-features
-      - skala-checkpoint
-
-    steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-    - name: Print CPU diagnostics
-      uses: ./.github/actions/cpu-diagnostics
-
-    - name: Setup micromamba
-      uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39 # v3
-      with:
-        environment-file: examples/fortran/ftorch_integration/environment.yml
-        environment-name: ftorch-dev
-        # Recreate native environments per runner; restored environments caused SIGILL failures.
-        cache-environment: false
-        cache-downloads: true
-
-    - name: Configure project
-      run: >-
-        cmake
-        -B build_example
-        -S examples/fortran/ftorch_integration
-        -G Ninja
-        -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX
-      shell: micromamba-shell {0}
-
-    - name: Build project
-      run: cmake --build build_example
-      shell: micromamba-shell {0}
-
-    - name: Install project
-      run: cmake --install build_example
-      shell: micromamba-shell {0}
-
-    - name: Download features
-      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
-      with:
-        name: pt-features
-        path: features
-
-    - name: Download checkpoint
-      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
-      with:
-        name: skala-checkpoint
-        path: .
-
-    - name: Run example
-      run: >-
-         Skala
-         ./skala-1.1-rev1.fun
-         ./features
       shell: micromamba-shell {0}

--- a/.github/workflows/model-benchmark.yml
+++ b/.github/workflows/model-benchmark.yml
@@ -3,8 +3,7 @@ name: Model benchmarks
 on:
   push:
     branches: [main]
-    paths:
-      - '.github/actions/cpu-diagnostics/action.yml'
+    paths: &model-benchmark-paths
       - '.github/workflows/model-benchmark.yml'
       - 'conftest.py'
       - 'environment-cpu.yml'
@@ -16,17 +15,7 @@ on:
       - 'tests/test_traced_model_comparison.py'
   pull_request:
     branches: [main]
-    paths:
-      - '.github/actions/cpu-diagnostics/action.yml'
-      - '.github/workflows/model-benchmark.yml'
-      - 'conftest.py'
-      - 'environment-cpu.yml'
-      - 'environment-gpu.yml'
-      - 'pyproject.toml'
-      - 'src/skala/__init__.py'
-      - 'src/skala/features.py'
-      - 'src/skala/functional/**'
-      - 'tests/test_traced_model_comparison.py'
+    paths: *model-benchmark-paths
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/model-benchmark.yml
+++ b/.github/workflows/model-benchmark.yml
@@ -2,9 +2,31 @@ name: Model benchmarks
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
+    paths:
+      - '.github/actions/cpu-diagnostics/action.yml'
+      - '.github/workflows/model-benchmark.yml'
+      - 'conftest.py'
+      - 'environment-cpu.yml'
+      - 'environment-gpu.yml'
+      - 'pyproject.toml'
+      - 'src/skala/__init__.py'
+      - 'src/skala/features.py'
+      - 'src/skala/functional/**'
+      - 'tests/test_traced_model_comparison.py'
   pull_request:
-    branches: [main, dev]
+    branches: [main]
+    paths:
+      - '.github/actions/cpu-diagnostics/action.yml'
+      - '.github/workflows/model-benchmark.yml'
+      - 'conftest.py'
+      - 'environment-cpu.yml'
+      - 'environment-gpu.yml'
+      - 'pyproject.toml'
+      - 'src/skala/__init__.py'
+      - 'src/skala/features.py'
+      - 'src/skala/functional/**'
+      - 'tests/test_traced_model_comparison.py'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/model-examples.yml
+++ b/.github/workflows/model-examples.yml
@@ -1,0 +1,197 @@
+name: "Model examples"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/actions/cpu-diagnostics/action.yml'
+      - '.github/workflows/model-examples.yml'
+      - 'environment-cpu.yml'
+      - 'examples/cpp/cpp_integration/**'
+      - 'examples/fortran/ftorch_integration/**'
+      - 'pyproject.toml'
+      - 'src/skala/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/actions/cpu-diagnostics/action.yml'
+      - '.github/workflows/model-examples.yml'
+      - 'environment-cpu.yml'
+      - 'examples/cpp/cpp_integration/**'
+      - 'examples/fortran/ftorch_integration/**'
+      - 'pyproject.toml'
+      - 'src/skala/**'
+
+permissions:
+  contents: read
+
+jobs:
+  skala-checkpoint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+
+    - name: Print CPU diagnostics
+      uses: ./.github/actions/cpu-diagnostics
+
+    - name: Setup Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      with:
+        version: "3.x"
+
+    - name: Install huggingface_hub CLI
+      run: pip install huggingface_hub
+
+    - name: Download checkpoint
+      run: >-
+         hf download microsoft/skala-1.1 skala-1.1-rev1.fun --local-dir .
+
+    - name: Upload checkpoint
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      with:
+        name: skala-checkpoint
+        path: skala-1.1-rev1.fun
+
+  pt-features:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Print CPU diagnostics
+      uses: ./.github/actions/cpu-diagnostics
+
+    - name: Setup micromamba
+      uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39 # v3
+      with:
+        environment-file: environment-cpu.yml
+        environment-name: skala-dev
+        # Recreate native environments per runner; restored environments caused SIGILL failures.
+        cache-environment: false
+        cache-downloads: true
+
+    - name: Install Skala
+      run: pip install -e .
+      shell: micromamba-shell {0}
+
+    - name: Generate features
+      run: >-
+        python examples/cpp/cpp_integration/prepare_inputs.py
+        --output-dir features
+      shell: micromamba-shell {0}
+
+    - name: Upload features
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      with:
+        name: pt-features
+        path: features
+
+  cpp:
+    runs-on: ubuntu-latest
+    needs:
+      - pt-features
+      - skala-checkpoint
+
+    steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+    - name: Print CPU diagnostics
+      uses: ./.github/actions/cpu-diagnostics
+
+    - name: Setup micromamba
+      uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39 # v3
+      with:
+        environment-file: examples/cpp/cpp_integration/environment.yml
+        environment-name: skala-cpp-integration
+        # Recreate native environments per runner; restored environments caused SIGILL failures.
+        cache-environment: false
+        cache-downloads: true
+
+    - name: Configure project
+      run: >-
+        cmake
+        -B build_example
+        -S examples/cpp/cpp_integration
+        -G Ninja
+      shell: micromamba-shell {0}
+
+    - name: Build project
+      run: cmake --build build_example
+      shell: micromamba-shell {0}
+
+    - name: Download features
+      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+      with:
+        name: pt-features
+        path: features
+
+    - name: Download checkpoint
+      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+      with:
+        name: skala-checkpoint
+        path: .
+
+    - name: Run example
+      run: >-
+        ./build_example/skala_cpp_integration
+        ./skala-1.1-rev1.fun
+        ./features
+      shell: micromamba-shell {0}
+
+  ftorch:
+    runs-on: ubuntu-latest
+    needs:
+      - pt-features
+      - skala-checkpoint
+
+    steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+    - name: Print CPU diagnostics
+      uses: ./.github/actions/cpu-diagnostics
+
+    - name: Setup micromamba
+      uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39 # v3
+      with:
+        environment-file: examples/fortran/ftorch_integration/environment.yml
+        environment-name: ftorch-dev
+        # Recreate native environments per runner; restored environments caused SIGILL failures.
+        cache-environment: false
+        cache-downloads: true
+
+    - name: Configure project
+      run: >-
+        cmake
+        -B build_example
+        -S examples/fortran/ftorch_integration
+        -G Ninja
+        -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX
+      shell: micromamba-shell {0}
+
+    - name: Build project
+      run: cmake --build build_example
+      shell: micromamba-shell {0}
+
+    - name: Install project
+      run: cmake --install build_example
+      shell: micromamba-shell {0}
+
+    - name: Download features
+      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+      with:
+        name: pt-features
+        path: features
+
+    - name: Download checkpoint
+      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+      with:
+        name: skala-checkpoint
+        path: .
+
+    - name: Run example
+      run: >-
+         Skala
+         ./skala-1.1-rev1.fun
+         ./features
+      shell: micromamba-shell {0}

--- a/.github/workflows/model-examples.yml
+++ b/.github/workflows/model-examples.yml
@@ -3,8 +3,7 @@ name: "Model examples"
 on:
   push:
     branches: [main]
-    paths:
-      - '.github/actions/cpu-diagnostics/action.yml'
+    paths: &model-example-paths
       - '.github/workflows/model-examples.yml'
       - 'environment-cpu.yml'
       - 'examples/cpp/cpp_integration/**'
@@ -13,14 +12,7 @@ on:
       - 'src/skala/**'
   pull_request:
     branches: [main]
-    paths:
-      - '.github/actions/cpu-diagnostics/action.yml'
-      - '.github/workflows/model-examples.yml'
-      - 'environment-cpu.yml'
-      - 'examples/cpp/cpp_integration/**'
-      - 'examples/fortran/ftorch_integration/**'
-      - 'pyproject.toml'
-      - 'src/skala/**'
+    paths: *model-example-paths
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,39 @@ name: Tests
 
 on:
   push:
-    branches: [ main, dev ]
+    branches: [main]
+    paths:
+      - '.github/actions/cpu-diagnostics/action.yml'
+      - '.github/workflows/test.yml'
+      - '.pre-commit-config.yaml'
+      - 'benchmarks/reference/**'
+      - 'conftest.py'
+      - 'docs/_ext/**'
+      - 'environment-cpu.yml'
+      - 'environment-gpu.yml'
+      - 'pyproject.toml'
+      - 'src/skala/**'
+      - 'tests/**'
+      - '**/*.py'
+      - '**/*.pyi'
+      - '**/*.ipynb'
   pull_request:
-    branches: [ main, dev ]
+    branches: [main]
+    paths:
+      - '.github/actions/cpu-diagnostics/action.yml'
+      - '.github/workflows/test.yml'
+      - '.pre-commit-config.yaml'
+      - 'benchmarks/reference/**'
+      - 'conftest.py'
+      - 'docs/_ext/**'
+      - 'environment-cpu.yml'
+      - 'environment-gpu.yml'
+      - 'pyproject.toml'
+      - 'src/skala/**'
+      - 'tests/**'
+      - '**/*.py'
+      - '**/*.pyi'
+      - '**/*.ipynb'
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,7 @@ name: Tests
 on:
   push:
     branches: [main]
-    paths:
-      - '.github/actions/cpu-diagnostics/action.yml'
+    paths: &test-paths
       - '.github/workflows/test.yml'
       - '.pre-commit-config.yaml'
       - 'benchmarks/reference/**'
@@ -20,21 +19,7 @@ on:
       - '**/*.ipynb'
   pull_request:
     branches: [main]
-    paths:
-      - '.github/actions/cpu-diagnostics/action.yml'
-      - '.github/workflows/test.yml'
-      - '.pre-commit-config.yaml'
-      - 'benchmarks/reference/**'
-      - 'conftest.py'
-      - 'docs/_ext/**'
-      - 'environment-cpu.yml'
-      - 'environment-gpu.yml'
-      - 'pyproject.toml'
-      - 'src/skala/**'
-      - 'tests/**'
-      - '**/*.py'
-      - '**/*.pyi'
-      - '**/*.ipynb'
+    paths: *test-paths
 
 permissions:
   contents: read
@@ -77,8 +62,8 @@ jobs:
       fail-fast: false
       matrix:
         runner: [ubuntu-latest]
-        python-version: ["3.11", "3.12", "3.13"]
-        pyscf-version: ["2.11", "2.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        pyscf-version: ["2.9", "2.11"]
         include:
           - runner: ubuntu-24.04-arm
             python-version: "3.12"
@@ -90,8 +75,6 @@ jobs:
     name: "Python=${{ matrix.python-version }} & PySCF=${{ matrix.pyscf-version }} @ ${{ matrix.runner }}"
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      with:
-        lfs: true
 
     - name: Print CPU diagnostics
       uses: ./.github/actions/cpu-diagnostics
@@ -106,12 +89,7 @@ jobs:
         cache-downloads: true
         create-args: >-
           python=${{ matrix.python-version }}
-
-    # Keep PySCF on PyPI: its wheels bundle XCFun instead of introducing Conda's
-    # pybind11 ABI 4 requirement, which conflicts with PyTorch >=2.9's ABI 11.
-    - name: Install matrix PySCF version
-      run: python -m pip install "pyscf==${{ matrix.pyscf-version }}"
-      shell: micromamba-shell {0}
+          pyscf=${{ matrix.pyscf-version }}
 
     - name: Install package in development mode
       run: |
@@ -202,11 +180,7 @@ jobs:
         cache-downloads: true
         create-args: >-
           python=3.12
-
-    # Keep PySCF on PyPI for the same XCFun/pybind11 ABI reason as the test matrix.
-    - name: Install profiling PySCF version
-      run: python -m pip install "pyscf==2.13.1"
-      shell: micromamba-shell {0}
+          pyscf=2.13.1
 
     - name: Install package in development mode
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,8 +62,8 @@ jobs:
       fail-fast: false
       matrix:
         runner: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
-        pyscf-version: ["2.9", "2.11"]
+        python-version: ["3.11", "3.12", "3.13"]
+        pyscf-version: ["2.11", "2.14"]
         include:
           - runner: ubuntu-24.04-arm
             python-version: "3.12"
@@ -75,6 +75,8 @@ jobs:
     name: "Python=${{ matrix.python-version }} & PySCF=${{ matrix.pyscf-version }} @ ${{ matrix.runner }}"
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        lfs: true
 
     - name: Print CPU diagnostics
       uses: ./.github/actions/cpu-diagnostics
@@ -89,7 +91,12 @@ jobs:
         cache-downloads: true
         create-args: >-
           python=${{ matrix.python-version }}
-          pyscf=${{ matrix.pyscf-version }}
+
+    # Keep PySCF on PyPI: its wheels bundle XCFun instead of introducing Conda's
+    # pybind11 ABI 4 requirement, which conflicts with PyTorch >=2.9's ABI 11.
+    - name: Install matrix PySCF version
+      run: python -m pip install "pyscf==${{ matrix.pyscf-version }}"
+      shell: micromamba-shell {0}
 
     - name: Install package in development mode
       run: |
@@ -180,7 +187,11 @@ jobs:
         cache-downloads: true
         create-args: >-
           python=3.12
-          pyscf=2.13.1
+
+    # Keep PySCF on PyPI for the same XCFun/pybind11 ABI reason as the test matrix.
+    - name: Install profiling PySCF version
+      run: python -m pip install "pyscf==2.13.1"
+      shell: micromamba-shell {0}
 
     - name: Install package in development mode
       run: |

--- a/examples/cpp/cpp_integration/README.md
+++ b/examples/cpp/cpp_integration/README.md
@@ -8,7 +8,7 @@ Set up the conda environment using the provided environment file:
 
 ```bash
 cd examples/cpp/cpp_integration
-conda env create -n skala_cpp_integration -f environment-cpu.yml
+conda env create -n skala_cpp_integration -f environment.yml
 conda activate skala_cpp_integration
 ```
 

--- a/examples/cpp/cpp_integration/environment.yml
+++ b/examples/cpp/cpp_integration/environment.yml
@@ -6,6 +6,6 @@ dependencies:
 - cxx-compiler
 - ninja
 - nlohmann_json
-- libtorch
-- pytorch  # Only required to produce example features.
+- libtorch * cpu_*
+- pytorch >=2.9 cpu_*  # Only required to produce example features.
 - skala

--- a/examples/cpp/cpp_integration/main.cpp
+++ b/examples/cpp/cpp_integration/main.cpp
@@ -95,12 +95,16 @@ get_exc_and_grad(const torch::jit::Method &exc_func, const FeatureDict &features
   std::vector<at::Tensor> input_tensors;
   std::vector<std::string> tensor_keys;
 
-  for (const auto &kv : features)
-  {
-    auto tensor_with_grad = kv.value().clone().requires_grad_(true);
-    features_with_grad.insert(kv.key(), tensor_with_grad);
-    input_tensors.push_back(tensor_with_grad);
-    tensor_keys.push_back(kv.key());
+  for (const auto& entry : features) {
+    std::string key = entry.key();
+    bool requires_grad = (key == "density" || key == "grad" || key == "kin" || key == "coarse_0_atomic_coords" || key == "grid_coords" || key == "grid_weights");
+
+    auto tensor = entry.value().clone().requires_grad_(requires_grad);
+    if (requires_grad) {
+      input_tensors.push_back(tensor);
+      tensor_keys.push_back(key);
+    }
+    features_with_grad.insert(key, tensor);
   }
 
   IValueList args;


### PR DESCRIPTION
## Summary

Reduce unnecessary GitHub Actions runs by limiting workflows to `main` and
triggering them only when their relevant inputs change.

Split the existing examples pipeline by consumer so GauXC changes do not run
the direct LibTorch and FTorch integrations, and model-example changes do not
start the full GauXC matrix.

## Changes

- Restrict Tests, Model benchmarks, GauXC examples, and Model examples to:
  - pull requests targeting `main`
  - pushes to `main`
- Add workflow-specific path filters.
- Reuse each path list between `push` and `pull_request` with YAML anchors.
- Had to fix the cpp model example as it was not CI tested