### PR TITLE
fix docs and run them in the ci

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,17 @@ name: Docs
 on:
   push:
     branches: [main]
+    paths: &docs-paths
+      - '.github/workflows/docs.yml'
+      - 'benchmark/pyproject.toml'
+      - 'pixi.lock'
+      - 'pixi.toml'
+      - 'pyproject.toml'
+      - 'skala/pyproject.toml'
+      - 'website/**'
+  pull_request:
+    branches: [main]
+    paths: *docs-paths
   workflow_dispatch:
 
 permissions:
@@ -35,9 +46,6 @@ jobs:
           locked: true
           cache: false
 
-      - name: Check environment consistency
-        run: python -m pip check
-
       - name: Build documentation
         run: |
           sphinx-build -b html website website/_build/html
@@ -55,6 +63,7 @@ jobs:
 
   deploy:
     needs: build
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
The docs pipeline failed because there was a pip check in there, the pixi environment does not have pip and it is not needed either. 

To prevent stuff like this in the future, the docs pipeline apart from the publishing now runs as well if any relevant code is changed.